### PR TITLE
#16 [STYLE] 로그인 페이지 분리 및 사이드바 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "snorose-front-admin",
       "version": "0.0.0",
       "dependencies": {
+        "@radix-ui/react-slot": "^1.2.3",
         "@tailwindcss/vite": "^4.1.14",
         "@tanstack/react-query": "^5.90.2",
         "class-variance-authority": "^0.7.1",
@@ -1039,6 +1040,39 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.38",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.38.tgz",
@@ -1709,7 +1743,7 @@
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.0.tgz",
       "integrity": "sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2295,7 +2329,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.2.3",
     "@tailwindcss/vite": "^4.1.14",
     "@tanstack/react-query": "^5.90.2",
     "class-variance-authority": "^0.7.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import {
   ExamReviewPage,
   MemberInfoPage,
   PointAdjustmentPage,
-  SignInPage,
+  LogInPage,
   PostPage,
   CommentPage,
 } from './pages';
@@ -13,20 +13,27 @@ import { Header, Sidebar } from './components';
 function App() {
   return (
     <BrowserRouter>
-      <div className='flex flex-col w-screen h-screen overflow-hidden'>
-        <Header />
-        <main className='flex h-[calc(100vh-3.5rem)]'>
-          <Sidebar />
-          <Routes>
-            <Route path='/' element={<SignInPage />} />
-            <Route path='/exam' element={<ExamReviewPage />} />
-            <Route path='/member' element={<MemberInfoPage />} />
-            <Route path='/point' element={<PointAdjustmentPage />} />
-            <Route path='/post' element={<PostPage />} />
-            <Route path='/comment' element={<CommentPage />} />
-          </Routes>
-        </main>
-      </div>
+      <Routes>
+        <Route path='/' element={<LogInPage />} />
+        <Route
+          path='/*'
+          element={
+            <div className='flex flex-col w-screen h-screen overflow-hidden'>
+              <Header />
+              <main className='flex h-[calc(100vh-3.5rem)]'>
+                <Sidebar />
+                <Routes>
+                  <Route path='/exam' element={<ExamReviewPage />} />
+                  <Route path='/member' element={<MemberInfoPage />} />
+                  <Route path='/point' element={<PointAdjustmentPage />} />
+                  <Route path='/post' element={<PostPage />} />
+                  <Route path='/comment' element={<CommentPage />} />
+                </Routes>
+              </main>
+            </div>
+          }
+        />
+      </Routes>
     </BrowserRouter>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -19,8 +19,8 @@ const Sidebar: React.FC = () => {
   ];
 
   return (
-    <nav className='p-4 flex flex-col gap-4 border-r-1 border-gray-200'>
-      <ul className='text-left flex flex-col gap-2'>
+    <nav className='p-6 py-10 flex flex-col border-r-1 border-gray-200 w-70'>
+      <ul className='text-left flex flex-col gap-6'>
         {MENU_ITEMS.map((item) => (
           <li
             key={item.path}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,60 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+        "icon-sm": "size-8",
+        "icon-lg": "size-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot : "button"
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/src/pages/LogInPage.tsx
+++ b/src/pages/LogInPage.tsx
@@ -1,0 +1,30 @@
+import { useNavigate } from 'react-router-dom';
+import { snoroseLogo } from '@/assets';
+import { Button } from '@/components/ui/button';
+
+export default function LogInPage() {
+  const navigate = useNavigate();
+
+  const handleLogin = () => {
+    navigate('/member');
+  };
+
+  return (
+    <main className='flex flex-col items-center justify-center w-full h-full gap-10'>
+      <div>
+        <img src={snoroseLogo} alt='logo' />
+      </div>
+
+      <div className=' bg-gray-100 p-4'>
+        <div>아이디</div>
+        <div>비밀번호</div>
+      </div>
+
+      <div>
+        <Button className='text-black h-20' onClick={handleLogin}>
+          로그인
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/SignInPage.tsx
+++ b/src/pages/SignInPage.tsx
@@ -1,3 +1,0 @@
-export default function SignInPage() {
-  return <div>SignInPage</div>;
-}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -2,5 +2,5 @@ export { default as CommentPage } from './CommentPage';
 export { default as ExamReviewPage } from './ExamReviewPage';
 export { default as MemberInfoPage } from './MemberInfoPage';
 export { default as PointAdjustmentPage } from './PointAdjustmentPage';
-export { default as SignInPage } from './SignInPage';
+export { default as LogInPage } from './LogInPage';
 export { default as PostPage } from './PostPage';


### PR DESCRIPTION
## 🔎 What is this PR?

Close #16


## 🎯 변경 사항

###### 주요 변경점을 설명해주세요.

- 로그인 페이지 분리 및 사이드바 수정

## 📸 스크린샷 (선택 사항)
- 로그인 버튼 클릭시 해당 페이지로 이동

<img width="2940" height="1664" alt="image" src="https://github.com/user-attachments/assets/3fc8107e-fb93-40f3-afb8-df03cd306fab" />

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
