### PR TITLE
[FEAT] #185 게시글 관리 메뉴 주석 및 포인트 단건 지급 기능 살리기

### DIFF
--- a/src/apis/points.ts
+++ b/src/apis/points.ts
@@ -8,9 +8,9 @@ import type {
   UpdatePointFreeze,
 } from '@/shared/types';
 
-// 포인트 증감
+// 어드민 포인트 증감
 export const postSinglePointAPI = async (data: AdjustSinglePoint) => {
-  const response = await axiosInstance.post('/v1/points', data);
+  const response = await axiosInstance.post('/v1/admin/points', data);
   return response.data;
 };
 

--- a/src/domains/Points/components/MemberInfoSection.tsx
+++ b/src/domains/Points/components/MemberInfoSection.tsx
@@ -2,7 +2,7 @@ import { Input, Label } from '@/shared/components/ui';
 import type { MemberInfo } from '@/shared/types';
 
 interface MemberInfoSectionProps {
-  searchedMember: MemberInfo;
+  searchedMember: MemberInfo | null;
 }
 
 export function MemberInfoSection({ searchedMember }: MemberInfoSectionProps) {

--- a/src/domains/Points/components/MemberInfoSection.tsx
+++ b/src/domains/Points/components/MemberInfoSection.tsx
@@ -3,15 +3,9 @@ import type { MemberInfo } from '@/shared/types';
 
 interface MemberInfoSectionProps {
   searchedMember: MemberInfo;
-  userId: number | null;
-  onUserIdChange: (value: number) => void;
 }
 
-export function MemberInfoSection({
-  searchedMember,
-  userId,
-  onUserIdChange,
-}: MemberInfoSectionProps) {
+export function MemberInfoSection({ searchedMember }: MemberInfoSectionProps) {
   const MEMBER_INFO = [
     {
       label: '이름',
@@ -32,6 +26,11 @@ export function MemberInfoSection({
       label: '학번',
       id: 'studentNumber',
       value: searchedMember?.studentNumber,
+    },
+    {
+      label: '회원 ID',
+      id: 'encryptedUserId',
+      value: searchedMember?.encryptedUserId,
     },
   ] as const;
 
@@ -54,19 +53,6 @@ export function MemberInfoSection({
             />
           </div>
         ))}
-
-        <div className='flex flex-col gap-1'>
-          <Label htmlFor='userId' required>
-            userId
-          </Label>
-          <Input
-            type='text'
-            id='userId'
-            placeholder='직접 입력해 주세요.'
-            value={userId ?? ''}
-            onChange={(e) => onUserIdChange(Number(e.target.value))}
-          />
-        </div>
       </div>
     </article>
   );

--- a/src/domains/Points/components/PointActionButtons.tsx
+++ b/src/domains/Points/components/PointActionButtons.tsx
@@ -6,7 +6,7 @@ import { POINT_CATEGORY_OPTIONS } from '@/shared/constants';
 type PointCategoryValue = (typeof POINT_CATEGORY_OPTIONS)[number]['value'];
 
 interface PointActionButtonsProps {
-  userId: number | null;
+  encryptedUserId: string | null;
   selectedCategory: PointCategoryValue | '';
   difference: string;
   memo: string;
@@ -15,7 +15,7 @@ interface PointActionButtonsProps {
 }
 
 export function PointActionButtons({
-  userId,
+  encryptedUserId,
   selectedCategory,
   difference,
   memo,
@@ -23,7 +23,7 @@ export function PointActionButtons({
   onApply,
 }: PointActionButtonsProps) {
   const handleApplyClick = () => {
-    if (!userId || !selectedCategory || !difference || !memo) {
+    if (!encryptedUserId?.trim() || !selectedCategory || !difference || !memo) {
       toast.info('모든 필수 항목을 입력해주세요.');
       return;
     }

--- a/src/pages/points/AdjustSinglePointPage.tsx
+++ b/src/pages/points/AdjustSinglePointPage.tsx
@@ -120,7 +120,7 @@ export default function AdjustSinglePointPage() {
         </div>
       </article>
 
-      <MemberInfoSection searchedMember={searchedMember as MemberInfo} />
+      <MemberInfoSection searchedMember={searchedMember} />
 
       <PointDetailSection
         selectedCategory={selectedCategory}

--- a/src/pages/points/AdjustSinglePointPage.tsx
+++ b/src/pages/points/AdjustSinglePointPage.tsx
@@ -21,7 +21,6 @@ import { postSinglePointAPI, searchUsersAPI } from '@/apis';
 export default function AdjustSinglePointPage() {
   const { user } = useAuth();
   const [searchedMember, setSearchedMember] = useState<MemberInfo | null>(null);
-  const [userId, setUserId] = useState<number | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<
     (typeof POINT_CATEGORY_OPTIONS)[number]['value'] | ''
   >('');
@@ -41,10 +40,6 @@ export default function AdjustSinglePointPage() {
     try {
       const data = await searchUsersAPI(searchQuery.trim());
       setSearchedMember(data.result);
-
-      if (userId === null) {
-        setUserId(data.result.userId);
-      }
     } catch (error: unknown) {
       toast.error(getErrorMessage(error, '회원 검색에 실패했습니다.'));
       setSearchedMember(null);
@@ -59,7 +54,6 @@ export default function AdjustSinglePointPage() {
 
   const handleResetButtonClick = () => {
     setSearchedMember(null);
-    setUserId(null);
     setSelectedCategory('');
     setSearchQuery('');
     setDifference('');
@@ -67,11 +61,15 @@ export default function AdjustSinglePointPage() {
   };
 
   const handleConfirmModalButtonClick = async () => {
+    if (!searchedMember) {
+      return;
+    }
+
     try {
       const numDifference = Number(difference);
 
       await postSinglePointAPI({
-        userId: userId as number,
+        encryptedUserId: searchedMember.encryptedUserId,
         difference: numDifference,
         category: selectedCategory,
         sourceId: user?.userId,
@@ -122,11 +120,7 @@ export default function AdjustSinglePointPage() {
         </div>
       </article>
 
-      <MemberInfoSection
-        searchedMember={searchedMember as MemberInfo}
-        userId={userId}
-        onUserIdChange={setUserId}
-      />
+      <MemberInfoSection searchedMember={searchedMember as MemberInfo} />
 
       <PointDetailSection
         selectedCategory={selectedCategory}
@@ -138,7 +132,7 @@ export default function AdjustSinglePointPage() {
       />
 
       <PointActionButtons
-        userId={userId}
+        encryptedUserId={searchedMember?.encryptedUserId ?? null}
         selectedCategory={selectedCategory}
         difference={difference}
         memo={memo}

--- a/src/shared/constants/sidebar-menus.ts
+++ b/src/shared/constants/sidebar-menus.ts
@@ -1,7 +1,7 @@
 import {
   // Bell,
   BookOpen,
-  FileText,
+  // FileText,
   HandCoins,
   type LucideIcon,
   User,
@@ -36,16 +36,16 @@ export const SIDEBAR_MENUS: SidebarMenu[] = [
       // },
     ],
   },
-  {
-    title: '게시글 관리',
-    icon: FileText,
-    items: [
-      {
-        title: '댓글 관리',
-        url: PATHS.POST_COMMENTS,
-      },
-    ],
-  },
+  // {
+  //   title: '게시글 관리',
+  //   icon: FileText,
+  //   items: [
+  //     {
+  //       title: '댓글 관리',
+  //       url: PATHS.POST_COMMENTS,
+  //     },
+  //   ],
+  // },
   {
     title: '시험 후기',
     icon: BookOpen,
@@ -60,10 +60,10 @@ export const SIDEBAR_MENUS: SidebarMenu[] = [
     title: '포인트 관리',
     icon: HandCoins,
     items: [
-      // {
-      //   title: '단일건 증감',
-      //   url: '/points/single',
-      // },
+      {
+        title: '단일건 증감',
+        url: PATHS.POINT_SINGLE,
+      },
       {
         title: '엑셀 업로드 지급',
         url: PATHS.POINT_UPLOAD_EXCEL,

--- a/src/shared/types/points.ts
+++ b/src/shared/types/points.ts
@@ -1,5 +1,5 @@
 export interface AdjustSinglePoint {
-  userId: number;
+  encryptedUserId: string;
   difference?: number;
   category: string;
   sourceId?: number;


### PR DESCRIPTION
## 🔎 What is this PR?

Close #185


## 🎯 변경 사항

###### 주요 변경점을 설명해주세요.
- 게시글 관리 메뉴 주석 처리
- `userId` >> `encryptedUserId`로 스펙변경에 따른 반영
- 회원 검색시 `encryptedUserId` 자동 입력되도록 기능 변경 (기존에 `userId` 직접 입력 필요)

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
