### PR TITLE
[FEAT] #213 댓글 삭제 및 노출 상태 변경 API 연동

### DIFF
--- a/src/apis/comments.ts
+++ b/src/apis/comments.ts
@@ -1,9 +1,11 @@
 import { axiosInstance } from '@/shared/axios/instance';
 
 import type {
+  AdminCommentBulkDeleteResponse,
   AdminCommentListResponse,
   AdminCommentResponse,
   AdminCommentSearchRequest,
+  AdminDeleteCommentResponse,
 } from '@/domains/Comments/types/comment';
 
 // 댓글 상세 조회 api
@@ -35,6 +37,38 @@ export const searchComments = async (
 ): Promise<AdminCommentListResponse> => {
   const response = await axiosInstance.post('/v1/admin/comments/search', body, {
     params: { page },
+  });
+  return response.data.result;
+};
+
+// 댓글 삭제 api
+export const deleteComment = async (
+  commentId: number
+): Promise<AdminDeleteCommentResponse> => {
+  const response = await axiosInstance.delete(
+    `/v1/admin/comments/${commentId}`
+  );
+  return response.data.result;
+};
+
+// 댓글 일괄 삭제 api
+export const bulkDeleteComments = async (
+  commentIds: number[]
+): Promise<AdminCommentBulkDeleteResponse> => {
+  const response = await axiosInstance.delete(`/v1/admin/comments`, {
+    data: { commentIds },
+  });
+  return response.data.result;
+};
+
+// 댓글 노출/숨김 일괄 업데이트 api
+export const updateCommentVisibility = async (
+  commentIds: number[],
+  isVisible: boolean
+): Promise<string> => {
+  const response = await axiosInstance.patch(`/v1/admin/comments/visibility`, {
+    commentIds,
+    isVisible,
   });
   return response.data.result;
 };

--- a/src/domains/Comments/components/CommentList.tsx
+++ b/src/domains/Comments/components/CommentList.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 
 import { useCommentSearch } from '@/domains/Comments/hooks/useCommentSearch';
+import { useDeleteComment } from '@/domains/Comments/hooks/useDeleteComment';
 
+import { useBulkDeleteComment } from '../hooks/useBulkDeleteComment';
 import BulkDeleteBar from './BulkDeleteBar';
 import CommentListItem from './CommentListItem';
 
@@ -11,15 +13,16 @@ interface CommentListProps {
 
 export default function CommentList({ selectedPostId }: CommentListProps) {
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
-  const [deletedIds, setDeletedIds] = useState<number[]>([]);
+
+  const { mutate: deleteComment } = useDeleteComment();
+  const { mutate: bulkDeleteComments } = useBulkDeleteComment();
   const { data: commentSearch } = useCommentSearch(0, {
     postId: selectedPostId ?? undefined,
   });
 
   const selectAllRef = useRef<HTMLInputElement>(null);
 
-  const rawComments = commentSearch?.data ?? [];
-  const comments = rawComments.filter((c) => !deletedIds.includes(c.commentId));
+  const comments = commentSearch?.data ?? [];
 
   const allIds = comments.map((c) => c.commentId);
   const isAllSelected =
@@ -46,15 +49,28 @@ export default function CommentList({ selectedPostId }: CommentListProps) {
   };
 
   const handleDelete = (commentId: number) => {
-    // TODO: 단일 삭제 API 연동
-    setDeletedIds((prev) => [...prev, commentId]);
-    setSelectedIds((prev) => prev.filter((id) => id !== commentId));
+    if (window.confirm('정말 이 댓글을 삭제하시겠습니까?')) {
+      deleteComment(commentId, {
+        onSuccess: () => {
+          setSelectedIds((prev) => prev.filter((id) => id !== commentId));
+        },
+      });
+    }
   };
 
   const handleBulkDelete = () => {
-    // TODO: 일괄 삭제 API 연동
-    setDeletedIds((prev) => [...prev, ...selectedIds]);
-    setSelectedIds([]);
+    if (selectedIds.length === 0) return;
+    if (
+      window.confirm(
+        `선택한 ${selectedIds.length}개의 댓글을 삭제하시겠습니까?`
+      )
+    ) {
+      bulkDeleteComments(selectedIds, {
+        onSuccess: () => {
+          setSelectedIds([]);
+        },
+      });
+    }
   };
 
   return (

--- a/src/domains/Comments/hooks/useBulkDeleteComment.ts
+++ b/src/domains/Comments/hooks/useBulkDeleteComment.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { bulkDeleteComments } from '@/apis';
+
+export const useBulkDeleteComment = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (commentIds: number[]) => bulkDeleteComments(commentIds),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['commentSearch'] });
+    },
+    onError: (error) => {
+      console.error('댓글 일괄 삭제 중 오류 발생:', error);
+      alert('댓글 일괄 삭제 중 오류가 발생했습니다. 다시 시도해주세요.');
+    },
+  });
+};

--- a/src/domains/Comments/hooks/useDeleteComment.ts
+++ b/src/domains/Comments/hooks/useDeleteComment.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { deleteComment } from '@/apis';
+
+export const useDeleteComment = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (commentId: number) => deleteComment(commentId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['commentSearch'] });
+    },
+    onError: (error) => {
+      console.error('댓글 삭제 중 오류 발생:', error);
+      alert('댓글 삭제 중 오류가 발생했습니다. 다시 시도해주세요.');
+    },
+  });
+};

--- a/src/domains/Comments/hooks/useUpdateCommentVisibility.ts
+++ b/src/domains/Comments/hooks/useUpdateCommentVisibility.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { updateCommentVisibility } from '@/apis';
+
+export const useUpdateCommentVisibility = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      commentIds,
+      visible,
+    }: {
+      commentIds: number[];
+      visible: boolean;
+    }) => updateCommentVisibility(commentIds, visible),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['commentSearch'] });
+    },
+    onError: (error) => {
+      console.error('댓글 가시성 업데이트 중 오류 발생:', error);
+      alert('댓글 가시성 업데이트 중 오류가 발생했습니다. 다시 시도해주세요.');
+    },
+  });
+};

--- a/src/domains/Comments/types/comment.ts
+++ b/src/domains/Comments/types/comment.ts
@@ -31,16 +31,11 @@ export interface AdminCommentListResponse {
   data: AdminCommentResponse[];
 }
 
-export interface DeleteCommentResponse {
-  isSuccess: boolean;
-  code: number;
-  message: string;
-  result: {
-    id: number;
-    encryptedUserId: string;
-    postId: number;
-    content: string;
-  };
+export interface AdminDeleteCommentResponse {
+  id: number;
+  encryptedUserId: string;
+  postId: number;
+  content: string;
 }
 
 export interface AdminCommentBulkDeleteRequest {
@@ -48,17 +43,17 @@ export interface AdminCommentBulkDeleteRequest {
 }
 
 export interface AdminCommentBulkDeleteResponse {
-  isSuccess: boolean;
-  code: number;
-  message: string;
-  result: {
-    requestedCount: number;
-    deletedCount: number;
-    failedCount: number;
-    deletedCommentIds: number[];
-    notDeletedComments: {
-      commentId: number;
-      reason: string;
-    }[];
-  };
+  requestedCount: number;
+  deletedCount: number;
+  failedCount: number;
+  deletedCommentIds: number[];
+  notDeletedComments: {
+    commentId: number;
+    reason: string;
+  }[];
+}
+
+export interface AdminCommentVisibilityUpdateRequest {
+  commentIds: number[];
+  isVisible: boolean;
 }


### PR DESCRIPTION
## 🔎 What is this PR?

Close #213 

- [Figma]()
- [Notion]()

## 🎯 변경 사항

###### 주요 변경점을 설명해주세요.

- 댓글 삭제 API 연동했습니다.
- 노출 상태 같은 경우 API 함수는 생성했지만 해당 ui가 없어 이후에 바로 ui 작업 후 연동 예정입니다.

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
