### PR TITLE
[REFACTOR] #215 댓글 관리 로직 모듈화 및 검색/노출 필터링 기능 고도화

### DIFF
--- a/src/domains/Comments/components/BulkDeleteBar.tsx
+++ b/src/domains/Comments/components/BulkDeleteBar.tsx
@@ -32,7 +32,7 @@ export default function BulkDeleteBar({
         >
           선택 해제
         </Button>
-        
+
         {onBulkToggleVisibility && (
           <Button
             type='button'

--- a/src/domains/Comments/components/BulkDeleteBar.tsx
+++ b/src/domains/Comments/components/BulkDeleteBar.tsx
@@ -1,16 +1,20 @@
-import { Trash2 } from 'lucide-react';
+import { Eye, EyeOff, Trash2 } from 'lucide-react';
 
 import { Button } from '@/shared/components/ui';
 
 interface BulkDeleteBarProps {
   selectedCount: number;
   onBulkDelete: () => void;
+  onBulkToggleVisibility?: () => void;
+  visibilityLabel?: '비공개' | '공개';
   onClearSelection: () => void;
 }
 
 export default function BulkDeleteBar({
   selectedCount,
   onBulkDelete,
+  onBulkToggleVisibility,
+  visibilityLabel = '비공개',
   onClearSelection,
 }: BulkDeleteBarProps) {
   if (selectedCount === 0) return null;
@@ -28,6 +32,24 @@ export default function BulkDeleteBar({
         >
           선택 해제
         </Button>
+        
+        {onBulkToggleVisibility && (
+          <Button
+            type='button'
+            variant='outline'
+            size='sm'
+            className='border-blue-200 bg-white text-blue-600 hover:bg-blue-50'
+            onClick={onBulkToggleVisibility}
+          >
+            {visibilityLabel === '비공개' ? (
+              <EyeOff className='mr-1 size-4' />
+            ) : (
+              <Eye className='mr-1 size-4' />
+            )}
+            일괄 {visibilityLabel}
+          </Button>
+        )}
+
         <Button
           type='button'
           variant='destructive'

--- a/src/domains/Comments/components/CommentList.tsx
+++ b/src/domains/Comments/components/CommentList.tsx
@@ -19,6 +19,7 @@ export default function CommentList({ selectedPostId }: CommentListProps) {
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
   const [keyword, setKeyword] = useState('');
   const [visibilityFilter, setVisibilityFilter] = useState('all');
+  const [submittedKeyword, setSubmittedKeyword] = useState('');
   const { mutate: deleteComment } = useDeleteComment();
   const { mutate: bulkDeleteComments } = useBulkDeleteComment();
 
@@ -27,11 +28,11 @@ export default function CommentList({ selectedPostId }: CommentListProps) {
     const body: AdminCommentSearchRequest = {
       postId: selectedPostId ?? undefined,
     };
-    if (keyword) body.content = keyword;
+    if (submittedKeyword) body.content = submittedKeyword;
     if (visibilityFilter === 'visible') body.isVisible = true;
     if (visibilityFilter === 'hidden') body.isVisible = false;
     return body;
-  }, [selectedPostId, keyword, visibilityFilter]);
+  }, [selectedPostId, submittedKeyword, visibilityFilter]);
 
   const {
     data: commentSearch,
@@ -109,6 +110,7 @@ export default function CommentList({ selectedPostId }: CommentListProps) {
 
   const handleSearch = () => {
     setIsSearchSubmitted(true);
+    setSubmittedKeyword(keyword);
   };
 
   return (
@@ -117,7 +119,7 @@ export default function CommentList({ selectedPostId }: CommentListProps) {
         <h2 className='text-2xl font-bold'>댓글 관리</h2>
         <p className='text-sm text-gray-500'>
           {selectedPostId
-            ? `전체 ${commentSearch?.totalCount || commentSearch?.data?.length}개`
+            ? `전체 ${commentSearch?.totalCount ?? commentSearch?.data?.length ?? ''}개`
             : '댓글 상세 검색을 이용하거나 왼쪽에서 게시글을 선택하세요.'}
         </p>
       </div>

--- a/src/domains/Comments/components/CommentList.tsx
+++ b/src/domains/Comments/components/CommentList.tsx
@@ -1,11 +1,15 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { Input, Select } from '@/shared/components/ui';
 
 import { useCommentSearch } from '@/domains/Comments/hooks/useCommentSearch';
 import { useDeleteComment } from '@/domains/Comments/hooks/useDeleteComment';
 
 import { useBulkDeleteComment } from '../hooks/useBulkDeleteComment';
+import type { AdminCommentSearchRequest } from '../types';
 import BulkDeleteBar from './BulkDeleteBar';
 import CommentListItem from './CommentListItem';
+import { useCommentVisibility } from './useCommentVisibility';
 
 interface CommentListProps {
   selectedPostId: number | null;
@@ -13,16 +17,44 @@ interface CommentListProps {
 
 export default function CommentList({ selectedPostId }: CommentListProps) {
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
-
+  const [keyword, setKeyword] = useState('');
+  const [visibilityFilter, setVisibilityFilter] = useState('all');
   const { mutate: deleteComment } = useDeleteComment();
   const { mutate: bulkDeleteComments } = useBulkDeleteComment();
-  const { data: commentSearch } = useCommentSearch(0, {
-    postId: selectedPostId ?? undefined,
-  });
+
+  // body 객체를 메모이제이션하여 참조값 변화로 인한 무한 요청 방지
+  const searchBody = useMemo(() => {
+    const body: AdminCommentSearchRequest = {
+      postId: selectedPostId ?? undefined,
+    };
+    if (keyword) body.content = keyword;
+    if (visibilityFilter === 'visible') body.isVisible = true;
+    if (visibilityFilter === 'hidden') body.isVisible = false;
+    return body;
+  }, [selectedPostId, keyword, visibilityFilter]);
+
+  const {
+    data: commentSearch,
+    setIsSearchSubmitted,
+    refetch,
+  } = useCommentSearch(0, searchBody);
+
+  // 게시글이 바뀌면 선택 상태와 키워드 초기화
+  useEffect(() => {
+    setSelectedIds([]);
+    setKeyword('');
+    setVisibilityFilter('all');
+    setIsSearchSubmitted(false);
+  }, [selectedPostId, setIsSearchSubmitted]);
 
   const selectAllRef = useRef<HTMLInputElement>(null);
 
   const comments = commentSearch?.data ?? [];
+  const {
+    visibilityLabel,
+    handleBulkToggleVisibility,
+    handleToggleVisibility,
+  } = useCommentVisibility(comments, selectedIds);
 
   const allIds = comments.map((c) => c.commentId);
   const isAllSelected =
@@ -53,6 +85,7 @@ export default function CommentList({ selectedPostId }: CommentListProps) {
       deleteComment(commentId, {
         onSuccess: () => {
           setSelectedIds((prev) => prev.filter((id) => id !== commentId));
+          refetch();
         },
       });
     }
@@ -68,9 +101,14 @@ export default function CommentList({ selectedPostId }: CommentListProps) {
       bulkDeleteComments(selectedIds, {
         onSuccess: () => {
           setSelectedIds([]);
+          refetch();
         },
       });
     }
+  };
+
+  const handleSearch = () => {
+    setIsSearchSubmitted(true);
   };
 
   return (
@@ -80,22 +118,52 @@ export default function CommentList({ selectedPostId }: CommentListProps) {
         <p className='text-sm text-gray-500'>
           {selectedPostId
             ? `전체 ${commentSearch?.totalCount || commentSearch?.data?.length}개`
-            : '왼쪽에서 게시글을 선택하면 댓글이 표시됩니다.'}
+            : '댓글 상세 검색을 이용하거나 왼쪽에서 게시글을 선택하세요.'}
         </p>
+      </div>
+
+      {/* 검색창 UI */}
+      <div className='flex flex-col gap-2'>
+        <div className='flex gap-2'>
+          <Select
+            value={visibilityFilter}
+            onValueChange={(v) => setVisibilityFilter(v)}
+          >
+            <Select.Trigger className='w-[120px] rounded-md border border-gray-200 bg-white px-3'>
+              <Select.Value placeholder='노출 상태' />
+            </Select.Trigger>
+            <Select.Content>
+              <Select.Item value='all'>전체</Select.Item>
+              <Select.Item value='visible'>공개</Select.Item>
+              <Select.Item value='hidden'>비공개</Select.Item>
+            </Select.Content>
+          </Select>
+          <Input
+            placeholder='댓글 내용으로 검색'
+            value={keyword}
+            onChange={(e) => setKeyword(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+            className='flex-1'
+          />
+          <button
+            onClick={handleSearch}
+            className='rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-800'
+          >
+            검색
+          </button>
+        </div>
       </div>
 
       <BulkDeleteBar
         selectedCount={selectedIds.length}
         onBulkDelete={handleBulkDelete}
+        onBulkToggleVisibility={handleBulkToggleVisibility}
+        visibilityLabel={visibilityLabel}
         onClearSelection={() => setSelectedIds([])}
       />
 
       <div className='flex-1 overflow-y-auto rounded-md border'>
-        {!selectedPostId ? (
-          <p className='py-10 text-center text-sm text-gray-400'>
-            게시글을 선택해 주세요.
-          </p>
-        ) : comments.length === 0 ? (
+        {comments.length === 0 ? (
           <p className='py-10 text-center text-sm text-gray-400'>
             댓글이 없습니다.
           </p>
@@ -118,6 +186,7 @@ export default function CommentList({ selectedPostId }: CommentListProps) {
                 isSelected={selectedIds.includes(comment.commentId)}
                 onSelect={handleSelect}
                 onDelete={handleDelete}
+                onToggleVisibility={handleToggleVisibility}
               />
             ))}
           </div>

--- a/src/domains/Comments/components/CommentListItem.tsx
+++ b/src/domains/Comments/components/CommentListItem.tsx
@@ -54,7 +54,10 @@ export default function CommentListItem({
             </Badge>
           )}
           {!comment.isVisible && (
-            <Badge variant='outline' className='bg-gray-100 text-xs text-gray-500'>
+            <Badge
+              variant='outline'
+              className='bg-gray-100 text-xs text-gray-500'
+            >
               비공개
             </Badge>
           )}
@@ -75,7 +78,9 @@ export default function CommentListItem({
             'text-gray-400 hover:text-blue-500',
             !comment.isVisible && 'text-blue-500'
           )}
-          onClick={() => onToggleVisibility(comment.commentId, comment.isVisible)}
+          onClick={() =>
+            onToggleVisibility(comment.commentId, comment.isVisible)
+          }
           title={comment.isVisible ? '비공개로 전환' : '공개로 전환'}
         >
           {comment.isVisible ? (

--- a/src/domains/Comments/components/CommentListItem.tsx
+++ b/src/domains/Comments/components/CommentListItem.tsx
@@ -1,4 +1,4 @@
-import { CornerDownRight, Trash2 } from 'lucide-react';
+import { CornerDownRight, Eye, EyeOff, Trash2 } from 'lucide-react';
 
 import { Badge, Button } from '@/shared/components/ui';
 import { cn } from '@/shared/lib';
@@ -11,6 +11,7 @@ interface CommentListItemProps {
   isSelected: boolean;
   onSelect: (commentId: number) => void;
   onDelete: (commentId: number) => void;
+  onToggleVisibility: (commentId: number, currentVisible: boolean) => void;
 }
 
 export default function CommentListItem({
@@ -18,6 +19,7 @@ export default function CommentListItem({
   isSelected,
   onSelect,
   onDelete,
+  onToggleVisibility,
 }: CommentListItemProps) {
   const isReply = comment.parentId !== null;
 
@@ -25,7 +27,8 @@ export default function CommentListItem({
     <div
       className={cn(
         'flex items-start gap-3 px-4 py-3',
-        isReply && 'bg-gray-50 pl-10'
+        isReply && 'bg-gray-50 pl-10',
+        !comment.isVisible && 'opacity-60'
       )}
     >
       {isReply && (
@@ -50,6 +53,11 @@ export default function CommentListItem({
               신고 {comment.reportCount}
             </Badge>
           )}
+          {!comment.isVisible && (
+            <Badge variant='outline' className='bg-gray-100 text-xs text-gray-500'>
+              비공개
+            </Badge>
+          )}
         </div>
         <p className='text-sm text-gray-700'>{comment.content}</p>
         <div className='flex items-center justify-between'>
@@ -58,15 +66,34 @@ export default function CommentListItem({
           </span>
         </div>
       </div>
-      <Button
-        type='button'
-        variant='ghost'
-        size='icon'
-        className='shrink-0 text-gray-400 hover:text-red-500'
-        onClick={() => onDelete(comment.commentId)}
-      >
-        <Trash2 className='size-4' />
-      </Button>
+      <div className='flex shrink-0 items-center gap-1'>
+        <Button
+          type='button'
+          variant='ghost'
+          size='icon'
+          className={cn(
+            'text-gray-400 hover:text-blue-500',
+            !comment.isVisible && 'text-blue-500'
+          )}
+          onClick={() => onToggleVisibility(comment.commentId, comment.isVisible)}
+          title={comment.isVisible ? '비공개로 전환' : '공개로 전환'}
+        >
+          {comment.isVisible ? (
+            <Eye className='size-4' />
+          ) : (
+            <EyeOff className='size-4' />
+          )}
+        </Button>
+        <Button
+          type='button'
+          variant='ghost'
+          size='icon'
+          className='text-gray-400 hover:text-red-500'
+          onClick={() => onDelete(comment.commentId)}
+        >
+          <Trash2 className='size-4' />
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/domains/Comments/components/PostDetailModal.tsx
+++ b/src/domains/Comments/components/PostDetailModal.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import DOMPurify from 'dompurify';
 import { CornerDownRight } from 'lucide-react';
 
@@ -19,9 +20,12 @@ export default function PostDetailModal({
   onClose: () => void;
 }) {
   const { data, isPending } = usePost(postId, deletedAt);
-  const { data: commentSearch } = useCommentSearch(0, {
+
+  const searchBody = useMemo(() => ({
     postId: postId ?? undefined,
-  });
+  }), [postId]);
+
+  const { data: commentSearch } = useCommentSearch(0, searchBody);
 
   return (
     <Dialog open={!!postId} onOpenChange={() => onClose()}>

--- a/src/domains/Comments/components/PostDetailModal.tsx
+++ b/src/domains/Comments/components/PostDetailModal.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+
 import DOMPurify from 'dompurify';
 import { CornerDownRight } from 'lucide-react';
 
@@ -21,9 +22,12 @@ export default function PostDetailModal({
 }) {
   const { data, isPending } = usePost(postId, deletedAt);
 
-  const searchBody = useMemo(() => ({
-    postId: postId ?? undefined,
-  }), [postId]);
+  const searchBody = useMemo(
+    () => ({
+      postId: postId ?? undefined,
+    }),
+    [postId]
+  );
 
   const { data: commentSearch } = useCommentSearch(0, searchBody);
 

--- a/src/domains/Comments/components/PostList.tsx
+++ b/src/domains/Comments/components/PostList.tsx
@@ -56,11 +56,21 @@ export default function PostList({
         title='게시글 관리'
         description='커뮤니티에 있는 모든 게시글과 남겨진 댓글을 관리합니다.'
       />
-      <Input
-        placeholder='게시글 제목, 작성자(닉네임), 게시글 ID로 검색'
-        value={keyword}
-        onChange={(e) => setKeyword(e.target.value)}
-      />
+      <div className='flex gap-2'>
+        <Input
+          placeholder='게시글 제목, 작성자(닉네임), 게시글 ID로 검색'
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && setKeyword(keyword)}
+          className='flex-1'
+        />
+        <button
+          className='rounded-md bg-gray-900 px-4 py-2 text-sm text-white hover:bg-gray-800'
+          onClick={() => setKeyword(keyword)}
+        >
+          검색
+        </button>
+      </div>
       <div className='flex items-center'>
         <Input
           type='date'

--- a/src/domains/Comments/components/useCommentVisibility.ts
+++ b/src/domains/Comments/components/useCommentVisibility.ts
@@ -1,0 +1,48 @@
+import { useUpdateCommentVisibility } from '../hooks/useUpdateCommentVisibility';
+
+export const useCommentVisibility = (
+  comments: { commentId: number; isVisible: boolean }[],
+  selectedIds: number[]
+) => {
+  const { mutate } = useUpdateCommentVisibility();
+  // 선택된 댓글들 중 하나라도 공개(isVisible: true) 상태인 게 있는지 확인
+  const selectedComments = comments.filter((c) =>
+    selectedIds.includes(c.commentId)
+  );
+  const anyVisible = selectedComments.some((c) => c.isVisible === true);
+  const visibilityLabel: '비공개' | '공개' = anyVisible ? '비공개' : '공개';
+  const handleBulkToggleVisibility = () => {
+    if (selectedIds.length === 0) return;
+
+    // 공개인 게 하나라도 있으면 모두 비공개(false)로, 아니면 모두 공개(true)로
+    const nextVisibleValue = !anyVisible;
+    const actionText = nextVisibleValue ? '공개' : '비공개';
+
+    if (
+      window.confirm(
+        `선택한 ${selectedIds.length}개의 댓글을 일괄 ${actionText} 처리하시겠습니까?`
+      )
+    ) {
+      mutate({
+        commentIds: selectedIds,
+        visible: nextVisibleValue,
+      });
+    }
+  };
+
+  const handleToggleVisibility = (
+    commentId: number,
+    currentVisible: boolean
+  ) => {
+    mutate({
+      commentIds: [commentId],
+      visible: !currentVisible,
+    });
+  };
+
+  return {
+    visibilityLabel,
+    handleBulkToggleVisibility,
+    handleToggleVisibility,
+  };
+};

--- a/src/domains/Comments/hooks/useCommentSearch.ts
+++ b/src/domains/Comments/hooks/useCommentSearch.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+
 import { useQuery } from '@tanstack/react-query';
 
 import type { AdminCommentSearchRequest } from '@/domains/Comments/types/comment';
@@ -12,7 +13,13 @@ export const useCommentSearch = (
   const [isSearchSubmitted, setIsSearchSubmitted] = useState(false);
 
   const query = useQuery({
-    queryKey: ['commentSearch', page, body.postId, body.content, body.isVisible],
+    queryKey: [
+      'commentSearch',
+      page,
+      body.postId,
+      body.content,
+      body.isVisible,
+    ],
     queryFn: () => searchComments(page, body),
     enabled: !!body.postId || isSearchSubmitted,
     select: (data) => {

--- a/src/domains/Comments/hooks/useCommentSearch.ts
+++ b/src/domains/Comments/hooks/useCommentSearch.ts
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import type { AdminCommentSearchRequest } from '@/domains/Comments/types/comment';
@@ -8,18 +9,24 @@ export const useCommentSearch = (
   page: number,
   body: AdminCommentSearchRequest
 ) => {
-  return useQuery({
-    queryKey: ['commentSearch', page, body],
+  const [isSearchSubmitted, setIsSearchSubmitted] = useState(false);
+
+  const query = useQuery({
+    queryKey: ['commentSearch', page, body.postId, body.content, body.isVisible],
     queryFn: () => searchComments(page, body),
-    enabled: !!body.postId,
+    enabled: !!body.postId || isSearchSubmitted,
     select: (data) => {
-      if (!data.data) return data;
+      if (!data || !data.data) return data;
       return {
         ...data,
-        data: [...data.data].sort((a, b) =>
-          a.createdAt.localeCompare(b.createdAt)
-        ),
+        data: [...data.data].sort((a, b) => {
+          const dateA = a.createdAt || '';
+          const dateB = b.createdAt || '';
+          return dateA.localeCompare(dateB);
+        }),
       };
     },
   });
+
+  return { ...query, setIsSearchSubmitted };
 };


### PR DESCRIPTION
## 🔎 What is this PR?

Close #215 

- [Figma]()
- [Notion]()

## 🎯 변경 사항

### 댓글 공개 범위(Visibility) 관리
* **개별 댓글 공개 여부 전환**: 댓글 목록에서 직접 개별 댓글의 공개 여부(공개/비공개)를 전환할 수 있는 기능을 추가했으며, 관련 UI 지표와 작업 버튼이 포함되었습니다. 
* **일괄 공개 여부 전환**: `BulkDeleteBar`에 새로운 버튼을 추가하고, 현재 선택된 댓글들의 상태에 따라 다음 공개 상태를 결정하는 로직을 구현하여 선택한 댓글들을 일괄적으로 전환할 수 있습니다. 

---

### 댓글 검색 및 필터링
* **검색 및 필터 기능 강화**: 키워드 및 공개 여부 필터를 적용하여 댓글 검색을 강화했으며, 이를 위한 UI 컨트롤을 추가했습니다. 불필요한 요청을 방지하기 위해 메모이제이션(memoized)된 검색 본문을 사용하도록 검색 로직을 리팩토링했습니다. 
* **검색 훅 업데이트**: 검색 훅(`useCommentSearch`)을 업데이트하여 명시적인 검색 제출을 지원하고, 쿼리 키 처리를 개선했으며, 쿼리의 올바른 활성화/비활성화 상태를 보장합니다. 

---

### UI/UX 개선 사항
* **검색 UI 개선**: 전용 검색 버튼, 개선된 플레이스홀더 텍스트, 결과가 없을 때의 직관적인 피드백을 도입하여 댓글 목록 및 게시물 목록 검색 UI를 개선했습니다. 
* **상태 시각화**: 댓글의 공개 상태를 쉽게 알아볼 수 있도록 시각적 단서(예: 비공개 댓글의 투명도 조절 및 배지 표시)를 추가했습니다. 

---

### 기술 리팩토링
* **커스텀 훅 분리**: 관심사 분리와 재사용성 향상을 위해 검색 및 공개 상태 로직을 커스텀 훅으로 리팩토링했습니다. 
* **PostDetailModal 최적화**: 일관된 동작과 성능을 위해 `PostDetailModal` 내의 검색 로직이 `useMemo`를 사용하도록 업데이트했습니다. 
## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
