### PR TITLE
[FEAT] #228 댓글 관리 UI 수정

### DIFF
--- a/src/apis/comments.ts
+++ b/src/apis/comments.ts
@@ -43,11 +43,8 @@ export const getPostCommentsAPI = async (
   page: number
 ): Promise<GetPostCommentsResponse> => {
   const response = await axiosInstance.get(`/v1/posts/${postId}/comments`, {
-    params: {
-      page,
-    },
+    params: { page },
   });
-
   return response.data;
 };
 
@@ -66,9 +63,7 @@ export const getCommentChildrenList = async (
 ): Promise<AdminCommentListResponse> => {
   const response = await axiosInstance.get(
     `/v1/admin/comments/${commentId}/children`,
-    {
-      params: { page },
-    }
+    { params: { page } }
   );
   return response.data.result;
 };
@@ -88,9 +83,7 @@ export const searchComments = async (
 export const deleteComment = async (
   commentId: number
 ): Promise<AdminDeleteCommentResponse> => {
-  const response = await axiosInstance.delete(
-    `/v1/admin/comments/${commentId}`
-  );
+  const response = await axiosInstance.delete(`/v1/admin/comments/${commentId}`);
   return response.data.result;
 };
 
@@ -108,9 +101,6 @@ export const bulkDeleteComments = async (
 export const updateCommentVisibility = async (
   body: AdminCommentVisibilityUpdateRequest
 ): Promise<string> => {
-  const response = await axiosInstance.patch(
-    `/v1/admin/comments/visibility`,
-    body
-  );
+  const response = await axiosInstance.patch(`/v1/admin/comments/visibility`, body);
   return response.data.result;
 };

--- a/src/apis/comments.ts
+++ b/src/apis/comments.ts
@@ -83,7 +83,9 @@ export const searchComments = async (
 export const deleteComment = async (
   commentId: number
 ): Promise<AdminDeleteCommentResponse> => {
-  const response = await axiosInstance.delete(`/v1/admin/comments/${commentId}`);
+  const response = await axiosInstance.delete(
+    `/v1/admin/comments/${commentId}`
+  );
   return response.data.result;
 };
 
@@ -101,6 +103,9 @@ export const bulkDeleteComments = async (
 export const updateCommentVisibility = async (
   body: AdminCommentVisibilityUpdateRequest
 ): Promise<string> => {
-  const response = await axiosInstance.patch(`/v1/admin/comments/visibility`, body);
+  const response = await axiosInstance.patch(
+    `/v1/admin/comments/visibility`,
+    body
+  );
   return response.data.result;
 };

--- a/src/domains/Comments/components/CommentBulkActionBar.tsx
+++ b/src/domains/Comments/components/CommentBulkActionBar.tsx
@@ -1,4 +1,5 @@
 import { Eye, EyeOff, RotateCcw, Trash2 } from 'lucide-react';
+
 import { Button } from '@/shared/components/ui';
 
 interface CommentBulkActionBarProps {
@@ -26,7 +27,7 @@ export default function CommentBulkActionBar({
         선택된 <strong className='text-red-700'>{selectedCount}</strong>개의
         댓글에 대해 일괄 동작을 적용할 수 있습니다.
       </span>
-      <div className='flex items-center gap-2 flex-wrap'>
+      <div className='flex flex-wrap items-center gap-2'>
         <Button
           variant='outline'
           size='sm'
@@ -52,12 +53,12 @@ export default function CommentBulkActionBar({
           disabled={isVisibilityPending}
           onClick={onBulkRestore}
         >
-          <RotateCcw className='h-3.5 w-3.5 text-green-650' /> 복구
+          <RotateCcw className='text-green-650 h-3.5 w-3.5' /> 복구
         </Button>
         <Button
           variant='destructive'
           size='sm'
-          className='h-8 bg-red-600 text-xs hover:bg-red-700 flex items-center gap-1'
+          className='flex h-8 items-center gap-1 bg-red-600 text-xs hover:bg-red-700'
           disabled={isDeletePending}
           onClick={onBulkDelete}
         >
@@ -67,4 +68,3 @@ export default function CommentBulkActionBar({
     </div>
   );
 }
-

--- a/src/domains/Comments/components/CommentBulkActionBar.tsx
+++ b/src/domains/Comments/components/CommentBulkActionBar.tsx
@@ -1,0 +1,59 @@
+import { Eye, EyeOff } from 'lucide-react';
+import { Button } from '@/shared/components/ui';
+
+
+interface CommentBulkActionBarProps {
+  selectedCount: number;
+  isVisibilityPending: boolean;
+  isDeletePending: boolean;
+  onBulkVisibility: (visible: boolean) => void;
+  onBulkDelete: () => void;
+}
+
+export default function CommentBulkActionBar({
+  selectedCount,
+  isVisibilityPending,
+  isDeletePending,
+  onBulkVisibility,
+  onBulkDelete,
+}: CommentBulkActionBarProps) {
+  if (selectedCount === 0) return null;
+
+  return (
+    <div className='flex items-center justify-between rounded-lg border border-red-200 bg-red-50/50 px-4 py-3 shadow-sm'>
+      <span className='text-sm font-medium text-red-800'>
+        선택된 <strong className='text-red-700'>{selectedCount}</strong>개의
+        댓글에 대해 일괄 동작을 적용할 수 있습니다.
+      </span>
+      <div className='flex items-center gap-2'>
+        <Button
+          variant='outline'
+          size='sm'
+          className='flex h-8 items-center gap-1 border-gray-300 bg-white text-xs'
+          disabled={isVisibilityPending}
+          onClick={() => onBulkVisibility(true)}
+        >
+          <Eye className='h-3.5 w-3.5' /> 일괄 공개
+        </Button>
+        <Button
+          variant='outline'
+          size='sm'
+          className='flex h-8 items-center gap-1 border-gray-300 bg-white text-xs'
+          disabled={isVisibilityPending}
+          onClick={() => onBulkVisibility(false)}
+        >
+          <EyeOff className='h-3.5 w-3.5' /> 일괄 비공개
+        </Button>
+        <Button
+          variant='destructive'
+          size='sm'
+          className='h-8 bg-red-600 text-xs hover:bg-red-700'
+          disabled={isDeletePending}
+          onClick={onBulkDelete}
+        >
+          일괄 삭제
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/domains/Comments/components/CommentBulkActionBar.tsx
+++ b/src/domains/Comments/components/CommentBulkActionBar.tsx
@@ -1,6 +1,6 @@
 import { Eye, EyeOff } from 'lucide-react';
-import { Button } from '@/shared/components/ui';
 
+import { Button } from '@/shared/components/ui';
 
 interface CommentBulkActionBarProps {
   selectedCount: number;

--- a/src/domains/Comments/components/CommentBulkActionBar.tsx
+++ b/src/domains/Comments/components/CommentBulkActionBar.tsx
@@ -1,5 +1,4 @@
-import { Eye, EyeOff } from 'lucide-react';
-
+import { Eye, EyeOff, RotateCcw, Trash2 } from 'lucide-react';
 import { Button } from '@/shared/components/ui';
 
 interface CommentBulkActionBarProps {
@@ -7,6 +6,7 @@ interface CommentBulkActionBarProps {
   isVisibilityPending: boolean;
   isDeletePending: boolean;
   onBulkVisibility: (visible: boolean) => void;
+  onBulkRestore: () => void;
   onBulkDelete: () => void;
 }
 
@@ -15,6 +15,7 @@ export default function CommentBulkActionBar({
   isVisibilityPending,
   isDeletePending,
   onBulkVisibility,
+  onBulkRestore,
   onBulkDelete,
 }: CommentBulkActionBarProps) {
   if (selectedCount === 0) return null;
@@ -25,35 +26,45 @@ export default function CommentBulkActionBar({
         선택된 <strong className='text-red-700'>{selectedCount}</strong>개의
         댓글에 대해 일괄 동작을 적용할 수 있습니다.
       </span>
-      <div className='flex items-center gap-2'>
+      <div className='flex items-center gap-2 flex-wrap'>
         <Button
           variant='outline'
           size='sm'
-          className='flex h-8 items-center gap-1 border-gray-300 bg-white text-xs'
+          className='flex h-8 items-center gap-1 border-gray-300 bg-white text-xs text-gray-700 hover:bg-gray-50'
           disabled={isVisibilityPending}
           onClick={() => onBulkVisibility(true)}
         >
-          <Eye className='h-3.5 w-3.5' /> 일괄 공개
+          <Eye className='h-3.5 w-3.5 text-blue-600' /> 비공개 해제
         </Button>
         <Button
           variant='outline'
           size='sm'
-          className='flex h-8 items-center gap-1 border-gray-300 bg-white text-xs'
+          className='flex h-8 items-center gap-1 border-gray-300 bg-white text-xs text-gray-700 hover:bg-gray-50'
           disabled={isVisibilityPending}
           onClick={() => onBulkVisibility(false)}
         >
-          <EyeOff className='h-3.5 w-3.5' /> 일괄 비공개
+          <EyeOff className='h-3.5 w-3.5 text-gray-500' /> 비공개
+        </Button>
+        <Button
+          variant='outline'
+          size='sm'
+          className='flex h-8 items-center gap-1 border-gray-300 bg-white text-xs text-gray-700 hover:bg-gray-50'
+          disabled={isVisibilityPending}
+          onClick={onBulkRestore}
+        >
+          <RotateCcw className='h-3.5 w-3.5 text-green-650' /> 복구
         </Button>
         <Button
           variant='destructive'
           size='sm'
-          className='h-8 bg-red-600 text-xs hover:bg-red-700'
+          className='h-8 bg-red-600 text-xs hover:bg-red-700 flex items-center gap-1'
           disabled={isDeletePending}
           onClick={onBulkDelete}
         >
-          일괄 삭제
+          <Trash2 className='h-3.5 w-3.5' /> 삭제
         </Button>
       </div>
     </div>
   );
 }
+

--- a/src/domains/Comments/components/CommentList.tsx
+++ b/src/domains/Comments/components/CommentList.tsx
@@ -23,24 +23,16 @@ export default function CommentList({ selectedPostId }: CommentListProps) {
   const { mutate: deleteComment } = useDeleteComment();
   const { mutate: bulkDeleteComments } = useBulkDeleteComment();
 
-  // body 객체를 메모이제이션하여 참조값 변화로 인한 무한 요청 방지
   const searchBody = useMemo(() => {
-    const body: AdminCommentSearchRequest = {
-      postId: selectedPostId ?? undefined,
-    };
+    const body: AdminCommentSearchRequest = { postId: selectedPostId ?? undefined };
     if (submittedKeyword) body.content = submittedKeyword;
     if (visibilityFilter === 'visible') body.isVisible = true;
     if (visibilityFilter === 'hidden') body.isVisible = false;
     return body;
   }, [selectedPostId, submittedKeyword, visibilityFilter]);
 
-  const {
-    data: commentSearch,
-    setIsSearchSubmitted,
-    refetch,
-  } = useCommentSearch(0, searchBody);
+  const { data: commentSearch, setIsSearchSubmitted, refetch } = useCommentSearch(0, searchBody);
 
-  // 게시글이 바뀌면 선택 상태와 키워드 초기화
   useEffect(() => {
     setSelectedIds([]);
     setKeyword('');
@@ -49,37 +41,25 @@ export default function CommentList({ selectedPostId }: CommentListProps) {
   }, [selectedPostId, setIsSearchSubmitted]);
 
   const selectAllRef = useRef<HTMLInputElement>(null);
-
   const comments = commentSearch?.data ?? [];
-  const {
-    visibilityLabel,
-    handleBulkToggleVisibility,
-    handleToggleVisibility,
-  } = useCommentVisibility(comments, selectedIds);
+  const { visibilityLabel, handleBulkToggleVisibility, handleToggleVisibility } =
+    useCommentVisibility(comments, selectedIds);
 
   const allIds = comments.map((c) => c.commentId);
-  const isAllSelected =
-    allIds.length > 0 && allIds.every((id) => selectedIds.includes(id));
-  const isSomeSelected =
-    allIds.some((id) => selectedIds.includes(id)) && !isAllSelected;
+  const isAllSelected = allIds.length > 0 && allIds.every((id) => selectedIds.includes(id));
+  const isSomeSelected = allIds.some((id) => selectedIds.includes(id)) && !isAllSelected;
 
   useEffect(() => {
-    if (selectAllRef.current) {
-      selectAllRef.current.indeterminate = isSomeSelected;
-    }
+    if (selectAllRef.current) selectAllRef.current.indeterminate = isSomeSelected;
   }, [isSomeSelected]);
 
-  const handleSelectAll = () => {
-    setSelectedIds(isAllSelected ? [] : allIds);
-  };
-
+  const handleSelectAll = () => setSelectedIds(isAllSelected ? [] : allIds);
   const handleSelect = (commentId: number) => {
     setSelectedIds((prev) =>
-      prev.includes(commentId)
-        ? prev.filter((id) => id !== commentId)
-        : [...prev, commentId]
+      prev.includes(commentId) ? prev.filter((id) => id !== commentId) : [...prev, commentId]
     );
   };
+
 
   const handleDelete = (commentId: number) => {
     if (window.confirm('정말 이 댓글을 삭제하시겠습니까?')) {

--- a/src/domains/Comments/components/CommentList.tsx
+++ b/src/domains/Comments/components/CommentList.tsx
@@ -24,14 +24,20 @@ export default function CommentList({ selectedPostId }: CommentListProps) {
   const { mutate: bulkDeleteComments } = useBulkDeleteComment();
 
   const searchBody = useMemo(() => {
-    const body: AdminCommentSearchRequest = { postId: selectedPostId ?? undefined };
+    const body: AdminCommentSearchRequest = {
+      postId: selectedPostId ?? undefined,
+    };
     if (submittedKeyword) body.content = submittedKeyword;
     if (visibilityFilter === 'visible') body.isVisible = true;
     if (visibilityFilter === 'hidden') body.isVisible = false;
     return body;
   }, [selectedPostId, submittedKeyword, visibilityFilter]);
 
-  const { data: commentSearch, setIsSearchSubmitted, refetch } = useCommentSearch(0, searchBody);
+  const {
+    data: commentSearch,
+    setIsSearchSubmitted,
+    refetch,
+  } = useCommentSearch(0, searchBody);
 
   useEffect(() => {
     setSelectedIds([]);
@@ -42,24 +48,31 @@ export default function CommentList({ selectedPostId }: CommentListProps) {
 
   const selectAllRef = useRef<HTMLInputElement>(null);
   const comments = commentSearch?.data ?? [];
-  const { visibilityLabel, handleBulkToggleVisibility, handleToggleVisibility } =
-    useCommentVisibility(comments, selectedIds);
+  const {
+    visibilityLabel,
+    handleBulkToggleVisibility,
+    handleToggleVisibility,
+  } = useCommentVisibility(comments, selectedIds);
 
   const allIds = comments.map((c) => c.commentId);
-  const isAllSelected = allIds.length > 0 && allIds.every((id) => selectedIds.includes(id));
-  const isSomeSelected = allIds.some((id) => selectedIds.includes(id)) && !isAllSelected;
+  const isAllSelected =
+    allIds.length > 0 && allIds.every((id) => selectedIds.includes(id));
+  const isSomeSelected =
+    allIds.some((id) => selectedIds.includes(id)) && !isAllSelected;
 
   useEffect(() => {
-    if (selectAllRef.current) selectAllRef.current.indeterminate = isSomeSelected;
+    if (selectAllRef.current)
+      selectAllRef.current.indeterminate = isSomeSelected;
   }, [isSomeSelected]);
 
   const handleSelectAll = () => setSelectedIds(isAllSelected ? [] : allIds);
   const handleSelect = (commentId: number) => {
     setSelectedIds((prev) =>
-      prev.includes(commentId) ? prev.filter((id) => id !== commentId) : [...prev, commentId]
+      prev.includes(commentId)
+        ? prev.filter((id) => id !== commentId)
+        : [...prev, commentId]
     );
   };
-
 
   const handleDelete = (commentId: number) => {
     if (window.confirm('정말 이 댓글을 삭제하시겠습니까?')) {

--- a/src/domains/Comments/components/CommentTable.tsx
+++ b/src/domains/Comments/components/CommentTable.tsx
@@ -1,9 +1,12 @@
 import { Loader2 } from 'lucide-react';
+
 import { Table } from '@/shared/components/ui';
+
 import { ExamReviewTablePagination } from '@/domains/Reviews/components';
+
 import { useCommentTableState } from '../hooks/useCommentTableState';
-import CommentTableRow from './CommentTableRow';
 import CommentBulkActionBar from './CommentBulkActionBar';
+import CommentTableRow from './CommentTableRow';
 
 interface CommentTableProps {
   searchParams?: {
@@ -60,7 +63,10 @@ export default function CommentTable({
   const isEmpty = !isLoading && comments.length === 0;
 
   return (
-    <div className='flex flex-col gap-3' onClick={() => setActivePopoverId(null)}>
+    <div
+      className='flex flex-col gap-3'
+      onClick={() => setActivePopoverId(null)}
+    >
       <CommentBulkActionBar
         selectedCount={selectedIds.length}
         isVisibilityPending={isVisibilityPending}
@@ -73,7 +79,10 @@ export default function CommentTable({
         <div className='w-full overflow-x-auto'>
           <Table className='w-full min-w-[1250px] table-fixed text-[13px]'>
             <Table.Header className='h-[42px] border-b border-gray-200 bg-gray-50 font-semibold text-gray-700'>
-              <Table.Head style={{ width: '40px' }} className='px-3 text-center'>
+              <Table.Head
+                style={{ width: '40px' }}
+                className='px-3 text-center'
+              >
                 <input
                   type='checkbox'
                   ref={selectAllRef}
@@ -103,10 +112,16 @@ export default function CommentTable({
               <Table.Head style={{ width: '330px' }} className='px-3 text-xs'>
                 내용 (더블클릭 상세조회)
               </Table.Head>
-              <Table.Head style={{ width: '120px' }} className='px-3 text-center text-xs'>
+              <Table.Head
+                style={{ width: '120px' }}
+                className='px-3 text-center text-xs'
+              >
                 상태
               </Table.Head>
-              <Table.Head style={{ width: '100px' }} className='px-3 text-center text-xs'>
+              <Table.Head
+                style={{ width: '100px' }}
+                className='px-3 text-center text-xs'
+              >
                 의심 키워드
               </Table.Head>
             </Table.Header>
@@ -123,7 +138,10 @@ export default function CommentTable({
                 </Table.Row>
               ) : isEmpty ? (
                 <Table.Row>
-                  <Table.Cell colSpan={10} className='h-48 text-center text-sm text-gray-400'>
+                  <Table.Cell
+                    colSpan={10}
+                    className='h-48 text-center text-sm text-gray-400'
+                  >
                     등록된 댓글이 없거나 검색 결과가 존재하지 않습니다.
                   </Table.Cell>
                 </Table.Row>
@@ -135,7 +153,9 @@ export default function CommentTable({
                     isSelected={selectedIds.includes(comment.commentId)}
                     onSelectToggle={(id) => {
                       setSelectedIds((prev) =>
-                        prev.includes(id) ? prev.filter((item) => item !== id) : [...prev, id]
+                        prev.includes(id)
+                          ? prev.filter((item) => item !== id)
+                          : [...prev, id]
                       );
                     }}
                     activePopoverId={activePopoverId}
@@ -163,4 +183,3 @@ export default function CommentTable({
     </div>
   );
 }
-

--- a/src/domains/Comments/components/CommentTable.tsx
+++ b/src/domains/Comments/components/CommentTable.tsx
@@ -1,0 +1,166 @@
+import { Loader2 } from 'lucide-react';
+import { Table } from '@/shared/components/ui';
+import { ExamReviewTablePagination } from '@/domains/Reviews/components';
+import { useCommentTableState } from '../hooks/useCommentTableState';
+import CommentTableRow from './CommentTableRow';
+import CommentBulkActionBar from './CommentBulkActionBar';
+
+interface CommentTableProps {
+  searchParams?: {
+    content?: string;
+    postId?: number;
+    parentId?: number | null;
+    encryptedUserId?: string;
+    boardId?: number;
+    isVisible?: boolean;
+    isKeywordExist?: boolean;
+    startDate?: string;
+    endDate?: string;
+    status?: string;
+  };
+  refreshKey?: number;
+  currentPage: number;
+  onPageChange: (page: number | ((prev: number) => number)) => void;
+}
+
+export default function CommentTable({
+  searchParams = {},
+  refreshKey,
+  currentPage,
+  onPageChange,
+}: CommentTableProps) {
+  const {
+    comments,
+    isLoading,
+    selectedIds,
+    setSelectedIds,
+    isAllSelected,
+    selectAllRef,
+    handleSelectAll,
+    activePopoverId,
+    setActivePopoverId,
+    popoverUser,
+    isUserLoading,
+    handleNicknameClick,
+    handleSingleVisibility,
+    handleFilterByPostId,
+    handleFilterByParentId,
+    handleBulkDelete,
+    handleBulkVisibility,
+    isDeletePending,
+    isVisibilityPending,
+    hasNext,
+  } = useCommentTableState({
+    searchParams,
+    refreshKey,
+    currentPage,
+    onPageChange,
+  });
+
+  const isEmpty = !isLoading && comments.length === 0;
+
+  return (
+    <div className='flex flex-col gap-3' onClick={() => setActivePopoverId(null)}>
+      <CommentBulkActionBar
+        selectedCount={selectedIds.length}
+        isVisibilityPending={isVisibilityPending}
+        isDeletePending={isDeletePending}
+        onBulkVisibility={handleBulkVisibility}
+        onBulkDelete={handleBulkDelete}
+      />
+
+      <div className='overflow-hidden rounded-md border border-gray-200 bg-white shadow-sm'>
+        <div className='w-full overflow-x-auto'>
+          <Table className='w-full min-w-[1250px] table-fixed text-[13px]'>
+            <Table.Header className='h-[42px] border-b border-gray-200 bg-gray-50 font-semibold text-gray-700'>
+              <Table.Head style={{ width: '40px' }} className='px-3 text-center'>
+                <input
+                  type='checkbox'
+                  ref={selectAllRef}
+                  checked={isAllSelected}
+                  onChange={handleSelectAll}
+                  className='cursor-pointer rounded border-gray-300'
+                />
+              </Table.Head>
+              <Table.Head style={{ width: '180px' }} className='px-3 text-xs'>
+                게시 시각 (비공개일)
+              </Table.Head>
+              <Table.Head style={{ width: '110px' }} className='px-3 text-xs'>
+                게시판
+              </Table.Head>
+              <Table.Head style={{ width: '120px' }} className='px-3 text-xs'>
+                닉네임 (클릭 드롭다운)
+              </Table.Head>
+              <Table.Head style={{ width: '80px' }} className='px-3 text-xs'>
+                댓글 ID
+              </Table.Head>
+              <Table.Head style={{ width: '95px' }} className='px-3 text-xs'>
+                상위 댓글 ID
+              </Table.Head>
+              <Table.Head style={{ width: '85px' }} className='px-3 text-xs'>
+                게시글 ID
+              </Table.Head>
+              <Table.Head style={{ width: '330px' }} className='px-3 text-xs'>
+                내용 (더블클릭 상세조회)
+              </Table.Head>
+              <Table.Head style={{ width: '120px' }} className='px-3 text-center text-xs'>
+                상태
+              </Table.Head>
+              <Table.Head style={{ width: '100px' }} className='px-3 text-center text-xs'>
+                의심 키워드
+              </Table.Head>
+            </Table.Header>
+
+            <Table.Body>
+              {isLoading ? (
+                <Table.Row>
+                  <Table.Cell colSpan={10} className='h-48 text-center'>
+                    <div className='flex items-center justify-center gap-2 text-gray-500'>
+                      <Loader2 className='h-5 w-5 animate-spin text-blue-600' />
+                      <span>댓글 데이터를 불러오는 중입니다...</span>
+                    </div>
+                  </Table.Cell>
+                </Table.Row>
+              ) : isEmpty ? (
+                <Table.Row>
+                  <Table.Cell colSpan={10} className='h-48 text-center text-sm text-gray-400'>
+                    등록된 댓글이 없거나 검색 결과가 존재하지 않습니다.
+                  </Table.Cell>
+                </Table.Row>
+              ) : (
+                comments.map((comment) => (
+                  <CommentTableRow
+                    key={comment.commentId}
+                    comment={comment}
+                    isSelected={selectedIds.includes(comment.commentId)}
+                    onSelectToggle={(id) => {
+                      setSelectedIds((prev) =>
+                        prev.includes(id) ? prev.filter((item) => item !== id) : [...prev, id]
+                      );
+                    }}
+                    activePopoverId={activePopoverId}
+                    onNicknameClick={handleNicknameClick}
+                    popoverUser={popoverUser}
+                    isUserLoading={isUserLoading}
+                    onClosePopover={() => setActivePopoverId(null)}
+                    onPageChange={onPageChange}
+                    onSingleVisibilityToggle={handleSingleVisibility}
+                    onFilterByPostId={handleFilterByPostId}
+                    onFilterByParentId={handleFilterByParentId}
+                  />
+                ))
+              )}
+            </Table.Body>
+          </Table>
+        </div>
+      </div>
+
+      <ExamReviewTablePagination
+        currentPage={currentPage}
+        onPageChange={onPageChange}
+        hasNext={hasNext}
+      />
+    </div>
+  );
+}
+

--- a/src/domains/Comments/components/CommentTable.tsx
+++ b/src/domains/Comments/components/CommentTable.tsx
@@ -50,6 +50,7 @@ export default function CommentTable({
     handleFilterByParentId,
     handleBulkDelete,
     handleBulkVisibility,
+    handleBulkRestore,
     isDeletePending,
     isVisibilityPending,
     hasNext,
@@ -72,6 +73,7 @@ export default function CommentTable({
         isVisibilityPending={isVisibilityPending}
         isDeletePending={isDeletePending}
         onBulkVisibility={handleBulkVisibility}
+        onBulkRestore={handleBulkRestore}
         onBulkDelete={handleBulkDelete}
       />
 

--- a/src/domains/Comments/components/CommentTableRow.tsx
+++ b/src/domains/Comments/components/CommentTableRow.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AlertTriangle } from 'lucide-react';
+
+import { Badge, Table } from '@/shared/components/ui';
+import { cn } from '@/shared/lib';
+import { formatDateTimeToMinutes } from '@/shared/utils';
+
+import type { AdminCommentResponse } from '../types/comment';
+import type { MemberInfo } from '@/shared/types';
+import {
+  formatCommentId,
+  formatPostId,
+  getBoardBadge,
+  getCommentStatus,
+  getRowStyle,
+  getStatusBadgeClass,
+} from '../utils/commentUtils';
+import MemberInfoPopover from './MemberInfoPopover';
+
+interface CommentTableRowProps {
+  comment: AdminCommentResponse;
+  isSelected: boolean;
+  onSelectToggle: (id: number) => void;
+  activePopoverId: number | null;
+  onNicknameClick: (e: React.MouseEvent, comment: AdminCommentResponse) => void;
+  popoverUser: MemberInfo | null;
+  isUserLoading: boolean;
+  onClosePopover: () => void;
+  onPageChange: (page: number | ((prev: number) => number)) => void;
+  onSingleVisibilityToggle: (comment: AdminCommentResponse) => void;
+  onFilterByPostId: (postId: number) => void;
+  onFilterByParentId: (parentId: number) => void;
+}
+
+export default function CommentTableRow({
+  comment,
+  isSelected,
+  onSelectToggle,
+  activePopoverId,
+  onNicknameClick,
+  popoverUser,
+  isUserLoading,
+  onClosePopover,
+  onPageChange,
+  onSingleVisibilityToggle,
+  onFilterByPostId,
+  onFilterByParentId,
+}: CommentTableRowProps) {
+  const navigate = useNavigate();
+  const status = getCommentStatus(comment);
+  const rowStyle = getRowStyle(status);
+  const board = getBoardBadge(comment.boardId);
+
+  return (
+    <Table.Row className={cn('border-b border-gray-100 last:border-0 [&_td]:h-[54px]', rowStyle)}>
+      <Table.Cell className='px-3 text-center' onClick={(e) => e.stopPropagation()}>
+        <input
+          type='checkbox'
+          checked={isSelected}
+          onChange={(e) => {
+            e.stopPropagation();
+            onSelectToggle(comment.commentId);
+          }}
+          className='rounded border-gray-300 cursor-pointer'
+        />
+      </Table.Cell>
+      <Table.Cell className='px-3 font-mono text-gray-600'>
+        {(() => {
+          const created = formatDateTimeToMinutes(comment.createdAt);
+          if (status !== '정상' && status !== '비공개해제') {
+            const changeDate = formatDateTimeToMinutes(comment.updatedAt || comment.createdAt);
+            return (
+              <div className='flex items-center gap-1.5 leading-none flex-wrap'>
+                <span>{created}</span>
+                <span className='text-[11px] text-gray-400 font-medium'>({changeDate})</span>
+              </div>
+            );
+          }
+          return created;
+        })()}
+      </Table.Cell>
+      <Table.Cell className='px-3'>
+        <Badge className={board.className}>{board.name}</Badge>
+      </Table.Cell>
+      <Table.Cell
+        className='px-3 font-bold cursor-pointer select-none relative text-gray-900'
+        onClick={(e) => onNicknameClick(e, comment)}
+      >
+        <div className='hover:underline hover:text-blue-700 transition-colors truncate'>
+          {comment.nickname || comment.userDisplay}
+        </div>
+        {activePopoverId === comment.commentId && (
+          <MemberInfoPopover
+            encryptedUserId={comment.encryptedUserId}
+            popoverUser={popoverUser}
+            isUserLoading={isUserLoading}
+            onClose={onClosePopover}
+            onPageChange={onPageChange}
+          />
+        )}
+      </Table.Cell>
+      <Table.Cell className='px-3 font-mono font-bold text-gray-800'>
+        {formatCommentId(comment.commentId)}
+      </Table.Cell>
+      <Table.Cell
+        className={cn(
+          'px-3 font-mono text-gray-500 select-all',
+          comment.parentId != null ? 'cursor-pointer hover:text-black transition-colors font-bold' : 'text-center'
+        )}
+        onDoubleClick={() => comment.parentId != null && onFilterByParentId(comment.parentId)}
+      >
+        {comment.parentId != null ? formatCommentId(comment.parentId) : <span className='text-gray-300'>-</span>}
+      </Table.Cell>
+      <Table.Cell
+        className='px-3 font-mono text-gray-800 font-bold select-all cursor-pointer'
+        onDoubleClick={() => onFilterByPostId(comment.postId)}
+      >
+        {formatPostId(comment.postId)}
+      </Table.Cell>
+      <Table.Cell
+        className='px-3 py-1 cursor-pointer select-text'
+        onDoubleClick={(e) => {
+          e.stopPropagation();
+          navigate(`/posts/${comment.postId}`);
+        }}
+      >
+
+        <div className='flex flex-col gap-0.5 justify-center h-full'>
+          <div
+            className={cn('max-w-[310px] truncate text-gray-700', comment.parentId != null && 'pl-3 font-normal')}
+            title={comment.content}
+          >
+            {comment.parentId != null && <span className='text-gray-400 mr-1'>↳</span>}
+            {comment.content}
+          </div>
+        </div>
+      </Table.Cell>
+      <Table.Cell className='px-3 text-center'>
+        <Badge
+          className={getStatusBadgeClass(status)}
+          onClick={(e) => {
+            e.stopPropagation();
+            onSingleVisibilityToggle(comment);
+          }}
+        >
+          {status}
+        </Badge>
+      </Table.Cell>
+      <Table.Cell className='px-3 text-center'>
+        {comment.isKeywordExist ? (
+          <div className='flex justify-center items-center' title='의심 키워드 존재'>
+            <AlertTriangle className='h-5 w-5 text-[#E65100]' />
+          </div>
+        ) : (
+          ''
+        )}
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+

--- a/src/domains/Comments/components/CommentTableRow.tsx
+++ b/src/domains/Comments/components/CommentTableRow.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+
 import { AlertTriangle } from 'lucide-react';
 
 import { Badge, Table } from '@/shared/components/ui';
 import { cn } from '@/shared/lib';
+import type { MemberInfo } from '@/shared/types';
 import { formatDateTimeToMinutes } from '@/shared/utils';
 
 import type { AdminCommentResponse } from '../types/comment';
-import type { MemberInfo } from '@/shared/types';
 import {
   formatCommentId,
   formatPostId,
@@ -53,8 +54,16 @@ export default function CommentTableRow({
   const board = getBoardBadge(comment.boardId);
 
   return (
-    <Table.Row className={cn('border-b border-gray-100 last:border-0 [&_td]:h-[54px]', rowStyle)}>
-      <Table.Cell className='px-3 text-center' onClick={(e) => e.stopPropagation()}>
+    <Table.Row
+      className={cn(
+        'border-b border-gray-100 last:border-0 [&_td]:h-[54px]',
+        rowStyle
+      )}
+    >
+      <Table.Cell
+        className='px-3 text-center'
+        onClick={(e) => e.stopPropagation()}
+      >
         <input
           type='checkbox'
           checked={isSelected}
@@ -62,18 +71,22 @@ export default function CommentTableRow({
             e.stopPropagation();
             onSelectToggle(comment.commentId);
           }}
-          className='rounded border-gray-300 cursor-pointer'
+          className='cursor-pointer rounded border-gray-300'
         />
       </Table.Cell>
       <Table.Cell className='px-3 font-mono text-gray-600'>
         {(() => {
           const created = formatDateTimeToMinutes(comment.createdAt);
           if (status !== '정상' && status !== '비공개해제') {
-            const changeDate = formatDateTimeToMinutes(comment.updatedAt || comment.createdAt);
+            const changeDate = formatDateTimeToMinutes(
+              comment.updatedAt || comment.createdAt
+            );
             return (
-              <div className='flex items-center gap-1.5 leading-none flex-wrap'>
+              <div className='flex flex-wrap items-center gap-1.5 leading-none'>
                 <span>{created}</span>
-                <span className='text-[11px] text-gray-400 font-medium'>({changeDate})</span>
+                <span className='text-[11px] font-medium text-gray-400'>
+                  ({changeDate})
+                </span>
               </div>
             );
           }
@@ -84,10 +97,10 @@ export default function CommentTableRow({
         <Badge className={board.className}>{board.name}</Badge>
       </Table.Cell>
       <Table.Cell
-        className='px-3 font-bold cursor-pointer select-none relative text-gray-900'
+        className='relative cursor-pointer px-3 font-bold text-gray-900 select-none'
         onClick={(e) => onNicknameClick(e, comment)}
       >
-        <div className='hover:underline hover:text-blue-700 transition-colors truncate'>
+        <div className='truncate transition-colors hover:text-blue-700 hover:underline'>
           {comment.nickname || comment.userDisplay}
         </div>
         {activePopoverId === comment.commentId && (
@@ -106,32 +119,44 @@ export default function CommentTableRow({
       <Table.Cell
         className={cn(
           'px-3 font-mono text-gray-500 select-all',
-          comment.parentId != null ? 'cursor-pointer hover:text-black transition-colors font-bold' : 'text-center'
+          comment.parentId != null
+            ? 'cursor-pointer font-bold transition-colors hover:text-black'
+            : 'text-center'
         )}
-        onDoubleClick={() => comment.parentId != null && onFilterByParentId(comment.parentId)}
+        onDoubleClick={() =>
+          comment.parentId != null && onFilterByParentId(comment.parentId)
+        }
       >
-        {comment.parentId != null ? formatCommentId(comment.parentId) : <span className='text-gray-300'>-</span>}
+        {comment.parentId != null ? (
+          formatCommentId(comment.parentId)
+        ) : (
+          <span className='text-gray-300'>-</span>
+        )}
       </Table.Cell>
       <Table.Cell
-        className='px-3 font-mono text-gray-800 font-bold select-all cursor-pointer'
+        className='cursor-pointer px-3 font-mono font-bold text-gray-800 select-all'
         onDoubleClick={() => onFilterByPostId(comment.postId)}
       >
         {formatPostId(comment.postId)}
       </Table.Cell>
       <Table.Cell
-        className='px-3 py-1 cursor-pointer select-text'
+        className='cursor-pointer px-3 py-1 select-text'
         onDoubleClick={(e) => {
           e.stopPropagation();
           navigate(`/posts/${comment.postId}`);
         }}
       >
-
-        <div className='flex flex-col gap-0.5 justify-center h-full'>
+        <div className='flex h-full flex-col justify-center gap-0.5'>
           <div
-            className={cn('max-w-[310px] truncate text-gray-700', comment.parentId != null && 'pl-3 font-normal')}
+            className={cn(
+              'max-w-[310px] truncate text-gray-700',
+              comment.parentId != null && 'pl-3 font-normal'
+            )}
             title={comment.content}
           >
-            {comment.parentId != null && <span className='text-gray-400 mr-1'>↳</span>}
+            {comment.parentId != null && (
+              <span className='mr-1 text-gray-400'>↳</span>
+            )}
             {comment.content}
           </div>
         </div>
@@ -149,7 +174,10 @@ export default function CommentTableRow({
       </Table.Cell>
       <Table.Cell className='px-3 text-center'>
         {comment.isKeywordExist ? (
-          <div className='flex justify-center items-center' title='의심 키워드 존재'>
+          <div
+            className='flex items-center justify-center'
+            title='의심 키워드 존재'
+          >
             <AlertTriangle className='h-5 w-5 text-[#E65100]' />
           </div>
         ) : (
@@ -159,5 +187,3 @@ export default function CommentTableRow({
     </Table.Row>
   );
 }
-
-

--- a/src/domains/Comments/components/MemberInfoPopover.tsx
+++ b/src/domains/Comments/components/MemberInfoPopover.tsx
@@ -1,7 +1,8 @@
 import { useNavigate } from 'react-router-dom';
-import { Loader2, X } from 'lucide-react';
-import type { MemberInfo } from '@/shared/types';
 
+import { Loader2, X } from 'lucide-react';
+
+import type { MemberInfo } from '@/shared/types';
 
 interface MemberInfoPopoverProps {
   encryptedUserId: string;
@@ -22,17 +23,17 @@ export default function MemberInfoPopover({
 
   return (
     <div
-      className='absolute left-3 top-10 z-50 w-72 rounded-lg border border-gray-250 bg-white p-4 shadow-xl text-xs text-gray-700 font-normal leading-relaxed'
+      className='border-gray-250 absolute top-10 left-3 z-50 w-72 rounded-lg border bg-white p-4 text-xs leading-relaxed font-normal text-gray-700 shadow-xl'
       onClick={(e) => e.stopPropagation()}
     >
-      <div className='flex justify-between items-center border-b border-gray-100 pb-2 mb-2'>
+      <div className='mb-2 flex items-center justify-between border-b border-gray-100 pb-2'>
         <span className='font-bold text-gray-900'>미니 회원 정보</span>
         <button
           onClick={(e) => {
             e.stopPropagation();
             onClose();
           }}
-          className='p-0.5 hover:bg-gray-100 rounded'
+          className='rounded p-0.5 hover:bg-gray-100'
         >
           <X className='h-3.5 w-3.5 text-gray-400' />
         </button>
@@ -44,7 +45,7 @@ export default function MemberInfoPopover({
         </div>
       ) : popoverUser ? (
         <div className='flex flex-col gap-2'>
-          <div className='grid grid-cols-2 gap-y-1 gap-x-2 text-gray-600 border-b border-gray-50 pb-2 mb-1'>
+          <div className='mb-1 grid grid-cols-2 gap-x-2 gap-y-1 border-b border-gray-50 pb-2 text-gray-600'>
             <div>
               이름:{' '}
               <strong className='text-gray-900'>
@@ -53,19 +54,19 @@ export default function MemberInfoPopover({
             </div>
             <div>
               아이디:{' '}
-              <strong className='text-gray-900 font-mono'>
+              <strong className='font-mono text-gray-900'>
                 {popoverUser.loginId || '미정'}
               </strong>
             </div>
             <div>
               학번:{' '}
-              <strong className='text-gray-900 font-mono'>
+              <strong className='font-mono text-gray-900'>
                 {popoverUser.studentNumber || '미정'}
               </strong>
             </div>
             <div>
               포인트:{' '}
-              <strong className='text-blue-600 font-bold'>
+              <strong className='font-bold text-blue-600'>
                 {popoverUser.pointBalance || 0} P
               </strong>
             </div>
@@ -74,7 +75,7 @@ export default function MemberInfoPopover({
               <strong
                 className={
                   popoverUser.isBlacklist
-                    ? 'text-red-600 font-semibold'
+                    ? 'font-semibold text-red-600'
                     : 'text-gray-900'
                 }
               >
@@ -86,7 +87,7 @@ export default function MemberInfoPopover({
               <strong
                 className={
                   (popoverUser.totalWarningCount ?? 0) > 0
-                    ? 'text-red-600 font-semibold'
+                    ? 'font-semibold text-red-600'
                     : 'text-gray-900'
                 }
               >
@@ -102,13 +103,13 @@ export default function MemberInfoPopover({
               params.set('encryptedUserId', encryptedUserId);
               navigate(`?${params.toString()}`, { replace: true });
             }}
-            className='w-full py-1 text-left hover:bg-blue-50 hover:text-blue-700 px-2 rounded text-gray-800 font-medium'
+            className='w-full rounded px-2 py-1 text-left font-medium text-gray-800 hover:bg-blue-50 hover:text-blue-700'
           >
             작성한 댓글 검색 조회
           </button>
         </div>
       ) : (
-        <p className='text-gray-400 text-center py-2'>사용자 상세 조회 실패</p>
+        <p className='py-2 text-center text-gray-400'>사용자 상세 조회 실패</p>
       )}
     </div>
   );

--- a/src/domains/Comments/components/MemberInfoPopover.tsx
+++ b/src/domains/Comments/components/MemberInfoPopover.tsx
@@ -1,0 +1,115 @@
+import { useNavigate } from 'react-router-dom';
+import { Loader2, X } from 'lucide-react';
+import type { MemberInfo } from '@/shared/types';
+
+
+interface MemberInfoPopoverProps {
+  encryptedUserId: string;
+  popoverUser: MemberInfo | null;
+  isUserLoading: boolean;
+  onClose: () => void;
+  onPageChange: (page: number | ((prev: number) => number)) => void;
+}
+
+export default function MemberInfoPopover({
+  encryptedUserId,
+  popoverUser,
+  isUserLoading,
+  onClose,
+  onPageChange,
+}: MemberInfoPopoverProps) {
+  const navigate = useNavigate();
+
+  return (
+    <div
+      className='absolute left-3 top-10 z-50 w-72 rounded-lg border border-gray-250 bg-white p-4 shadow-xl text-xs text-gray-700 font-normal leading-relaxed'
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className='flex justify-between items-center border-b border-gray-100 pb-2 mb-2'>
+        <span className='font-bold text-gray-900'>미니 회원 정보</span>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}
+          className='p-0.5 hover:bg-gray-100 rounded'
+        >
+          <X className='h-3.5 w-3.5 text-gray-400' />
+        </button>
+      </div>
+
+      {isUserLoading ? (
+        <div className='flex justify-center py-4'>
+          <Loader2 className='h-5 w-5 animate-spin text-blue-600' />
+        </div>
+      ) : popoverUser ? (
+        <div className='flex flex-col gap-2'>
+          <div className='grid grid-cols-2 gap-y-1 gap-x-2 text-gray-600 border-b border-gray-50 pb-2 mb-1'>
+            <div>
+              이름:{' '}
+              <strong className='text-gray-900'>
+                {popoverUser.userName || '미정'}
+              </strong>
+            </div>
+            <div>
+              아이디:{' '}
+              <strong className='text-gray-900 font-mono'>
+                {popoverUser.loginId || '미정'}
+              </strong>
+            </div>
+            <div>
+              학번:{' '}
+              <strong className='text-gray-900 font-mono'>
+                {popoverUser.studentNumber || '미정'}
+              </strong>
+            </div>
+            <div>
+              포인트:{' '}
+              <strong className='text-blue-600 font-bold'>
+                {popoverUser.pointBalance || 0} P
+              </strong>
+            </div>
+            <div>
+              강등이력:{' '}
+              <strong
+                className={
+                  popoverUser.isBlacklist
+                    ? 'text-red-600 font-semibold'
+                    : 'text-gray-900'
+                }
+              >
+                {popoverUser.isBlacklist ? '있음' : '없음'}
+              </strong>
+            </div>
+            <div>
+              경고횟수:{' '}
+              <strong
+                className={
+                  (popoverUser.totalWarningCount ?? 0) > 0
+                    ? 'text-red-600 font-semibold'
+                    : 'text-gray-900'
+                }
+              >
+                {popoverUser.totalWarningCount ?? 0} 회
+              </strong>
+            </div>
+          </div>
+          <button
+            onClick={() => {
+              onClose();
+              onPageChange(1);
+              const params = new URLSearchParams();
+              params.set('encryptedUserId', encryptedUserId);
+              navigate(`?${params.toString()}`, { replace: true });
+            }}
+            className='w-full py-1 text-left hover:bg-blue-50 hover:text-blue-700 px-2 rounded text-gray-800 font-medium'
+          >
+            작성한 댓글 검색 조회
+          </button>
+        </div>
+      ) : (
+        <p className='text-gray-400 text-center py-2'>사용자 상세 조회 실패</p>
+      )}
+    </div>
+  );
+}

--- a/src/domains/Comments/hooks/useCommentList.ts
+++ b/src/domains/Comments/hooks/useCommentList.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { searchComments } from '@/apis';
+
+import type { AdminCommentSearchRequest } from '../types/comment';
+
+interface UseCommentListParams {
+  page: number;
+  body: AdminCommentSearchRequest;
+  enabled?: boolean;
+}
+
+export const useCommentList = ({
+  page,
+  body,
+  enabled = true,
+}: UseCommentListParams) => {
+  return useQuery({
+    queryKey: ['comments', page, body],
+    queryFn: () => searchComments(page, body),
+    enabled,
+  });
+};

--- a/src/domains/Comments/hooks/useCommentTableState.ts
+++ b/src/domains/Comments/hooks/useCommentTableState.ts
@@ -173,7 +173,6 @@ export function useCommentTableState({
     );
   };
 
-
   // 체크박스 제어
   const allCommentIds = comments.map((c) => c.commentId);
   const isAllSelected =

--- a/src/domains/Comments/hooks/useCommentTableState.ts
+++ b/src/domains/Comments/hooks/useCommentTableState.ts
@@ -1,0 +1,284 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { toast } from 'sonner';
+
+import type { MemberInfo } from '@/shared/types';
+
+import { extractFirstSearchMember } from '@/domains/MemberInfo/utils/memberDirectory';
+
+import { searchUsersAPI } from '@/apis/users';
+
+import type { AdminCommentResponse } from '../types/comment';
+import { getCommentStatus } from '../utils/commentUtils';
+import { useBulkDeleteComment } from './useBulkDeleteComment';
+import { useCommentList } from './useCommentList';
+import { useUpdateCommentVisibility } from './useUpdateCommentVisibility';
+
+interface UseCommentTableStateProps {
+  searchParams: {
+    content?: string;
+    postId?: number;
+    parentId?: number | null;
+    encryptedUserId?: string;
+    boardId?: number;
+    isVisible?: boolean;
+    isKeywordExist?: boolean;
+    startDate?: string;
+    endDate?: string;
+    status?: string;
+  };
+  refreshKey?: number;
+  currentPage: number;
+  onPageChange: (page: number | ((prev: number) => number)) => void;
+}
+
+export function useCommentTableState({
+  searchParams,
+  refreshKey,
+  currentPage,
+  onPageChange,
+}: UseCommentTableStateProps) {
+  const navigate = useNavigate();
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [sortBy] = useState<'reportCount' | 'createdAt'>('createdAt');
+  const [sortDir] = useState<'asc' | 'desc'>('desc');
+
+  // 닉네임 클릭 팝오버 상태
+  const [activePopoverId, setActivePopoverId] = useState<number | null>(null);
+  const [popoverUser, setPopoverUser] = useState<MemberInfo | null>(null);
+  const [isUserLoading, setIsUserLoading] = useState(false);
+
+  // 검색 조건 변경 시 선택 초기화 및 팝오버 닫기
+  useEffect(() => {
+    setSelectedIds([]);
+    setActivePopoverId(null);
+  }, [
+    searchParams.content,
+    searchParams.postId,
+    searchParams.parentId,
+    searchParams.encryptedUserId,
+    searchParams.boardId,
+    searchParams.isVisible,
+    searchParams.isKeywordExist,
+    searchParams.startDate,
+    searchParams.endDate,
+    searchParams.status,
+  ]);
+
+  const { data, isLoading, refetch } = useCommentList({
+    page: currentPage,
+    body: {
+      content: searchParams.content,
+      postId: searchParams.postId,
+      parentId: searchParams.parentId,
+      encryptedUserId: searchParams.encryptedUserId,
+      boardId: searchParams.boardId,
+      isVisible: searchParams.isVisible,
+      isKeywordExist: searchParams.isKeywordExist,
+      startDate: searchParams.startDate,
+      endDate: searchParams.endDate,
+    },
+  });
+
+  useEffect(() => {
+    if (refreshKey) void refetch();
+  }, [refreshKey, refetch]);
+
+  const comments = useMemo<AdminCommentResponse[]>(() => {
+    let list = data?.data ?? [];
+
+    // 상태 필터링 (클라이언트 보완 필터)
+    if (searchParams.status && searchParams.status !== '전체') {
+      list = list.filter((c) => getCommentStatus(c) === searchParams.status);
+    }
+
+    return [...list].sort((a, b) => {
+      if (sortBy === 'reportCount') {
+        return sortDir === 'asc'
+          ? a.reportCount - b.reportCount
+          : b.reportCount - a.reportCount;
+      }
+      const ta = new Date(a.createdAt).getTime();
+      const tb = new Date(b.createdAt).getTime();
+      return sortDir === 'asc' ? ta - tb : tb - ta;
+    });
+  }, [data, sortBy, sortDir, searchParams.status]);
+
+  const hasNext = data?.hasNext ?? false;
+
+  const { mutate: bulkDelete, isPending: isDeletePending } =
+    useBulkDeleteComment();
+  const { mutate: bulkVisibility, isPending: isVisibilityPending } =
+    useUpdateCommentVisibility();
+
+  const handleBulkDelete = () => {
+    if (selectedIds.length === 0) return;
+    if (
+      !window.confirm(
+        `선택한 ${selectedIds.length}개의 댓글을 삭제하시겠습니까?`
+      )
+    )
+      return;
+    bulkDelete(selectedIds, {
+      onSuccess: (res) => {
+        toast.success(`${res.deletedCount}개의 댓글이 삭제되었습니다.`);
+        setSelectedIds([]);
+        void refetch();
+      },
+      onError: () => toast.error('댓글 일괄 삭제 중 오류가 발생했습니다.'),
+    });
+  };
+
+  const handleBulkVisibility = (isVisible: boolean) => {
+    if (selectedIds.length === 0) return;
+    bulkVisibility(
+      { commentIds: selectedIds, isVisible },
+      {
+        onSuccess: () => {
+          toast.success('댓글 노출 여부가 성공적으로 변경되었습니다.');
+          setSelectedIds([]);
+          void refetch();
+        },
+        onError: () =>
+          toast.error('노출 상태 일괄 변경 중 오류가 발생했습니다.'),
+      }
+    );
+  };
+
+  // 체크박스 제어
+  const allCommentIds = comments.map((c) => c.commentId);
+  const isAllSelected =
+    allCommentIds.length > 0 &&
+    allCommentIds.every((id) => selectedIds.includes(id));
+  const isSomeSelected =
+    allCommentIds.some((id) => selectedIds.includes(id)) && !isAllSelected;
+
+  const selectAllRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (selectAllRef.current)
+      selectAllRef.current.indeterminate = isSomeSelected;
+  }, [isSomeSelected]);
+
+  const handleSelectAll = () => {
+    if (isAllSelected) {
+      setSelectedIds((prev) =>
+        prev.filter((id) => !allCommentIds.includes(id))
+      );
+    } else {
+      setSelectedIds((prev) =>
+        Array.from(new Set([...prev, ...allCommentIds]))
+      );
+    }
+  };
+
+  // 닉네임 클릭 핸들러
+  const handleNicknameClick = async (
+    e: React.MouseEvent,
+    comment: AdminCommentResponse
+  ) => {
+    e.stopPropagation();
+
+    if (activePopoverId === comment.commentId) {
+      setActivePopoverId(null);
+      setPopoverUser(null);
+      return;
+    }
+
+    setActivePopoverId(comment.commentId);
+    setPopoverUser(null);
+    setIsUserLoading(true);
+
+    try {
+      const res = await searchUsersAPI(comment.nickname || comment.userDisplay);
+      const member = extractFirstSearchMember(res?.result);
+      if (member) {
+        setPopoverUser(member);
+      } else {
+        setPopoverUser({
+          encryptedUserId: comment.encryptedUserId,
+          loginId: '정보 없음',
+          userName: comment.nickname || comment.userDisplay,
+          email: '',
+          nickname: comment.nickname || comment.userDisplay,
+          userRoleId: 1,
+          studentNumber: '정보 없음',
+          major: '정보 없음',
+          birthday: '',
+          pointBalance: 0,
+          createdAt: '',
+          authenticatedAt: null,
+          totalWarningCount: 0,
+          isBlacklist: false,
+          blacklistStartDate: null,
+          blacklistEndDate: null,
+        });
+      }
+    } catch (err) {
+      console.error(err);
+      toast.error('회원 상세 조회에 실패했습니다.');
+    } finally {
+      setIsUserLoading(false);
+    }
+  };
+
+  // 비공개 해제 / 삭제 복구 단건 토글 액션
+  const handleSingleVisibility = (comment: AdminCommentResponse) => {
+    const isCurrentlyVisible = comment.isVisible;
+    bulkVisibility(
+      { commentIds: [comment.commentId], isVisible: !isCurrentlyVisible },
+      {
+        onSuccess: () => {
+          toast.success(
+            !isCurrentlyVisible
+              ? '댓글이 공개로 전환되었습니다.'
+              : '댓글이 비공개 처리되었습니다.'
+          );
+          void refetch();
+        },
+        onError: () => toast.error('상태 변경 실패'),
+      }
+    );
+  };
+
+  // 더블클릭 필터 적용 유틸리티
+  const handleFilterByPostId = (postId: number) => {
+    onPageChange(1);
+    const newParams = new URLSearchParams(window.location.search);
+    newParams.set('postId', String(postId));
+    newParams.set('page', '1');
+    navigate(`?${newParams.toString()}`, { replace: true });
+  };
+
+  const handleFilterByParentId = (parentId: number) => {
+    onPageChange(1);
+    const newParams = new URLSearchParams(window.location.search);
+    newParams.set('parentId', String(parentId));
+    newParams.set('page', '1');
+    navigate(`?${newParams.toString()}`, { replace: true });
+  };
+
+  return {
+    comments,
+    isLoading,
+    selectedIds,
+    setSelectedIds,
+    isAllSelected,
+    isSomeSelected,
+    selectAllRef,
+    handleSelectAll,
+    activePopoverId,
+    setActivePopoverId,
+    popoverUser,
+    isUserLoading,
+    handleNicknameClick,
+    handleSingleVisibility,
+    handleFilterByPostId,
+    handleFilterByParentId,
+    handleBulkDelete,
+    handleBulkVisibility,
+    isDeletePending,
+    isVisibilityPending,
+    hasNext,
+  };
+}

--- a/src/domains/Comments/hooks/useCommentTableState.ts
+++ b/src/domains/Comments/hooks/useCommentTableState.ts
@@ -114,12 +114,20 @@ export function useCommentTableState({
 
   const handleBulkDelete = () => {
     if (selectedIds.length === 0) return;
-    if (
-      !window.confirm(
-        `선택한 ${selectedIds.length}개의 댓글을 삭제하시겠습니까?`
-      )
-    )
-      return;
+
+    const hasSelectedParentWithChildren = comments.some(
+      (c) =>
+        selectedIds.includes(c.commentId) &&
+        c.parentId === null &&
+        comments.some((child) => child.parentId === c.commentId)
+    );
+
+    const message = hasSelectedParentWithChildren
+      ? '하위댓글도 모두 삭제하시겠습니까?'
+      : `선택한 ${selectedIds.length}개의 댓글을 삭제하시겠습니까?`;
+
+    if (!window.confirm(message)) return;
+
     bulkDelete(selectedIds, {
       onSuccess: (res) => {
         toast.success(`${res.deletedCount}개의 댓글이 삭제되었습니다.`);
@@ -136,7 +144,11 @@ export function useCommentTableState({
       { commentIds: selectedIds, isVisible },
       {
         onSuccess: () => {
-          toast.success('댓글 노출 여부가 성공적으로 변경되었습니다.');
+          toast.success(
+            isVisible
+              ? '선택한 댓글의 비공개가 해제되었습니다.'
+              : '선택한 댓글이 비공개 처리되었습니다.'
+          );
           setSelectedIds([]);
           void refetch();
         },
@@ -145,6 +157,22 @@ export function useCommentTableState({
       }
     );
   };
+
+  const handleBulkRestore = () => {
+    if (selectedIds.length === 0) return;
+    bulkVisibility(
+      { commentIds: selectedIds, isVisible: true },
+      {
+        onSuccess: () => {
+          toast.success('선택한 댓글이 성공적으로 복구되었습니다.');
+          setSelectedIds([]);
+          void refetch();
+        },
+        onError: () => toast.error('댓글 복구 중 오류가 발생했습니다.'),
+      }
+    );
+  };
+
 
   // 체크박스 제어
   const allCommentIds = comments.map((c) => c.commentId);
@@ -277,6 +305,7 @@ export function useCommentTableState({
     handleFilterByParentId,
     handleBulkDelete,
     handleBulkVisibility,
+    handleBulkRestore,
     isDeletePending,
     isVisibilityPending,
     hasNext,

--- a/src/domains/Comments/hooks/useDeleteComment.ts
+++ b/src/domains/Comments/hooks/useDeleteComment.ts
@@ -9,6 +9,7 @@ export const useDeleteComment = () => {
     mutationFn: (commentId: number) => deleteComment(commentId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['commentSearch'] });
+      queryClient.invalidateQueries({ queryKey: ['comments'] });
     },
     onError: (error) => {
       console.error('댓글 삭제 중 오류 발생:', error);

--- a/src/domains/Comments/hooks/useUpdateCommentVisibility.ts
+++ b/src/domains/Comments/hooks/useUpdateCommentVisibility.ts
@@ -12,6 +12,7 @@ export const useUpdateCommentVisibility = () => {
       updateCommentVisibility(body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['commentSearch'] });
+      queryClient.invalidateQueries({ queryKey: ['comments'] });
     },
     onError: (error) => {
       console.error('댓글 가시성 업데이트 중 오류 발생:', error);

--- a/src/domains/Comments/types/comment.ts
+++ b/src/domains/Comments/types/comment.ts
@@ -11,6 +11,9 @@ export interface AdminCommentResponse {
   nickname: string;
   content: string;
   reportCount: number;
+  updatedAt?: string | null;
+  deletedAt?: string | null;
+  statusType?: string | null;
 }
 
 export interface AdminCommentSearchRequest {

--- a/src/domains/Comments/utils/commentUtils.ts
+++ b/src/domains/Comments/utils/commentUtils.ts
@@ -1,0 +1,149 @@
+import type { AdminCommentResponse } from '../types/comment';
+
+// 게시판 이름 매핑 및 배지 스타일 (함박눈방, 첫눈온방, 만년설방, 시험후기)
+export const getBoardBadge = (boardId: number) => {
+  const mapping: Record<number, { name: string; className: string }> = {
+    1: {
+      name: '함박눈방',
+      className:
+        'bg-[#F3E8FF] text-[#6B21A8] hover:bg-[#F3E8FF] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    11: {
+      name: '함박눈방',
+      className:
+        'bg-[#F3E8FF] text-[#6B21A8] hover:bg-[#F3E8FF] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    21: {
+      name: '함박눈방',
+      className:
+        'bg-[#F3E8FF] text-[#6B21A8] hover:bg-[#F3E8FF] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    2: {
+      name: '첫눈온방',
+      className:
+        'bg-[#E0F2FE] text-[#0369A1] hover:bg-[#E0F2FE] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    12: {
+      name: '첫눈온방',
+      className:
+        'bg-[#E0F2FE] text-[#0369A1] hover:bg-[#E0F2FE] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    22: {
+      name: '첫눈온방',
+      className:
+        'bg-[#E0F2FE] text-[#0369A1] hover:bg-[#E0F2FE] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    3: {
+      name: '만년설방',
+      className:
+        'bg-[#E0F7FA] text-[#006064] hover:bg-[#E0F7FA] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    13: {
+      name: '만년설방',
+      className:
+        'bg-[#E0F7FA] text-[#006064] hover:bg-[#E0F7FA] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    23: {
+      name: '만년설방',
+      className:
+        'bg-[#E0F7FA] text-[#006064] hover:bg-[#E0F7FA] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    4: {
+      name: '시험후기',
+      className:
+        'bg-[#FCE7F3] text-[#9D174D] hover:bg-[#FCE7F3] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    14: {
+      name: '시험후기',
+      className:
+        'bg-[#FCE7F3] text-[#9D174D] hover:bg-[#FCE7F3] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    24: {
+      name: '시험후기',
+      className:
+        'bg-[#FCE7F3] text-[#9D174D] hover:bg-[#FCE7F3] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+  };
+  return (
+    mapping[boardId] || {
+      name: `게시판 ${boardId}`,
+      className:
+        'bg-gray-100 text-gray-700 font-semibold px-2 py-0.5 rounded-full',
+    }
+  );
+};
+
+// 2. 댓글 상태 분류 헬퍼 함수
+export const getCommentStatus = (comment: AdminCommentResponse): string => {
+  if (comment.statusType) {
+    const mapping: Record<string, string> = {
+      REPORTED: '신고누적',
+      DELETED: '삭제됨',
+      ADMIN_DELETED: '관리자삭제',
+      ADMIN_HIDDEN: '관리자비공개',
+      RESTORED: '복구',
+      UNHIDDEN: '비공개해제',
+      NONE: '정상',
+    };
+    return mapping[comment.statusType] || comment.statusType;
+  }
+
+  // 폴백용 클라이언트 유추 로직
+  if (comment.reportCount >= 5 && !comment.isVisible) {
+    return '신고누적';
+  }
+  if (comment.deletedAt != null) {
+    return '삭제됨';
+  }
+  if (!comment.isVisible) {
+    return '관리자비공개';
+  }
+  return '정상';
+};
+
+// 상태별 Row 배경색 매핑 함수
+export const getRowStyle = (status: string) => {
+  switch (status) {
+    case '신고누적':
+      return 'bg-[#FFF9E6] hover:bg-[#FFF2CC] border-b border-gray-100 transition-colors text-yellow-950';
+    case '삭제됨':
+      return 'bg-[#FFF0F0] hover:bg-[#FFE3E3] border-b border-gray-100 transition-colors text-gray-500 opacity-90';
+    case '관리자삭제':
+      return 'bg-[#FFEBEB] hover:bg-[#FFD6D6] border-b border-gray-100 transition-colors text-red-950';
+    case '관리자비공개':
+      return 'bg-[#F5F7FA] hover:bg-[#E4E8ED] border-b border-gray-100 transition-colors text-slate-900';
+    case '복구':
+      return 'bg-[#EBF7EE] hover:bg-[#D5EEDC] border-b border-gray-100 transition-colors text-green-950';
+    case '비공개해제':
+      return 'bg-[#EBF3FC] hover:bg-[#D5E4F9] border-b border-gray-100 transition-colors text-blue-950';
+    default:
+      return 'bg-white hover:bg-gray-50/50 border-b border-gray-100 text-gray-800';
+  }
+};
+
+// 상태별 배지 스타일 매핑 함수
+export const getStatusBadgeClass = (status: string) => {
+  switch (status) {
+    case '정상':
+      return 'bg-[#EBF7EE] text-[#2A7E3E] border-[#B2E2BD] hover:bg-[#EBF7EE] font-semibold text-[11px] px-2 py-0.5 rounded border';
+    case '삭제됨':
+      return 'bg-[#FFF0F0] text-[#D32F2F] border-[#FFCDD2] hover:bg-[#FFF0F0] font-semibold text-[11px] px-2 py-0.5 rounded border';
+    case '관리자삭제':
+      return 'bg-[#FFEBEB] text-[#C62828] border-[#EF9A9A] hover:bg-[#FFEBEB] font-semibold text-[11px] px-2 py-0.5 rounded border';
+    case '복구':
+      return 'bg-[#EBF7EE] text-[#2A7E3E] border-[#B2E2BD] hover:bg-[#EBF7EE] font-semibold text-[11px] px-2 py-0.5 rounded border';
+    case '신고누적':
+      return 'bg-[#FFF3E0] text-[#E65100] border-[#FFE0B2] hover:bg-[#FFF3E0] font-semibold text-[11px] px-2 py-0.5 rounded border';
+    case '관리자비공개':
+      return 'bg-[#ECEFF1] text-[#37474F] border-[#CFD8DC] hover:bg-[#ECEFF1] font-semibold text-[11px] px-2 py-0.5 rounded border';
+    case '비공개해제':
+      return 'bg-[#E3F2FD] text-[#0D47A1] border-[#BBDEFB] hover:bg-[#E3F2FD] font-semibold text-[11px] px-2 py-0.5 rounded border';
+    default:
+      return 'bg-gray-50 text-gray-600 border-gray-200 hover:bg-gray-50 font-semibold text-[11px] px-2 py-0.5 rounded border';
+  }
+};
+
+// ID 포맷터
+export const formatCommentId = (id: number) =>
+  `C${String(id).padStart(3, '0')}`;
+export const formatPostId = (id: number) => `P${String(id).padStart(3, '0')}`;

--- a/src/pages/posts/PostCommentPage.tsx
+++ b/src/pages/posts/PostCommentPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { PageHeader } from '@/shared/components';
+
 import CommentTable from '@/domains/Comments/components/CommentTable';
 
 export default function PostCommentPage() {

--- a/src/pages/posts/PostCommentPage.tsx
+++ b/src/pages/posts/PostCommentPage.tsx
@@ -1,36 +1,130 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
-import CommentList from '@/domains/Comments/components/CommentList';
-import PostDetailModal from '@/domains/Comments/components/PostDetailModal';
-import PostList from '@/domains/Comments/components/PostList';
-import type { AdminGetPostResponse } from '@/domains/Comments/types';
+import { PageHeader } from '@/shared/components';
+import CommentTable from '@/domains/Comments/components/CommentTable';
 
 export default function PostCommentPage() {
-  const [selectedPostId, setSelectedPostId] = useState<number | null>(null);
-  const [modalPostId, setModalPostId] = useState<AdminGetPostResponse | null>(
-    null
+  const [searchParamsFromUrl, setSearchParamsFromUrl] = useSearchParams();
+  const [refreshKey] = useState(0);
+  const [searchParams, setSearchParams] = useState<{
+    content?: string;
+    postId?: number;
+    parentId?: number | null;
+    encryptedUserId?: string;
+    boardId?: number;
+    isVisible?: boolean;
+    isKeywordExist?: boolean;
+    startDate?: string;
+    endDate?: string;
+    status?: string;
+  }>({});
+
+  // URL에서 페이지 번호 복원
+  const currentPageFromUrl = parseInt(
+    searchParamsFromUrl.get('page') || '1',
+    10
+  );
+  const [currentPage, setCurrentPage] = useState<number>(
+    currentPageFromUrl || 1
   );
 
-  const handleSelectPost = (post: AdminGetPostResponse | null) => {
-    setSelectedPostId(post?.postId ?? null);
+  // URL의 페이지 번호가 변경되면 state 업데이트
+  useEffect(() => {
+    const pageFromUrl = parseInt(searchParamsFromUrl.get('page') || '1', 10);
+    if (pageFromUrl !== currentPage) {
+      setCurrentPage(pageFromUrl);
+    }
+  }, [searchParamsFromUrl, currentPage]);
+
+  // URL에서 검색 옵션들 복원
+  useEffect(() => {
+    const params: typeof searchParams = {};
+
+    const content = searchParamsFromUrl.get('content');
+    if (content) params.content = content;
+
+    const postId = searchParamsFromUrl.get('postId');
+    if (postId) {
+      const parsed = parseInt(postId, 10);
+      if (!isNaN(parsed)) params.postId = parsed;
+    }
+
+    const parentId = searchParamsFromUrl.get('parentId');
+    if (parentId) {
+      if (parentId === 'null') {
+        params.parentId = null;
+      } else {
+        const parsed = parseInt(parentId, 10);
+        if (!isNaN(parsed)) params.parentId = parsed;
+      }
+    }
+
+    const encryptedUserId = searchParamsFromUrl.get('encryptedUserId');
+    if (encryptedUserId) params.encryptedUserId = encryptedUserId;
+
+    const boardId = searchParamsFromUrl.get('boardId');
+    if (boardId) {
+      const parsed = parseInt(boardId, 10);
+      if (!isNaN(parsed)) params.boardId = parsed;
+    }
+
+    const isVisible = searchParamsFromUrl.get('isVisible');
+    if (isVisible === 'true') {
+      params.isVisible = true;
+    } else if (isVisible === 'false') {
+      params.isVisible = false;
+    }
+
+    const isKeywordExist = searchParamsFromUrl.get('isKeywordExist');
+    if (isKeywordExist === 'true') {
+      params.isKeywordExist = true;
+    } else if (isKeywordExist === 'false') {
+      params.isKeywordExist = false;
+    }
+
+    const status = searchParamsFromUrl.get('status');
+    if (status) params.status = status;
+
+    const startDate = searchParamsFromUrl.get('startDate');
+    if (startDate) params.startDate = startDate;
+
+    const endDate = searchParamsFromUrl.get('endDate');
+    if (endDate) params.endDate = endDate;
+
+    setSearchParams(params);
+  }, [searchParamsFromUrl]);
+
+  const handlePageChange = (
+    pageOrUpdater: number | ((prev: number) => number)
+  ) => {
+    setCurrentPage((prev) => {
+      const next =
+        typeof pageOrUpdater === 'function'
+          ? pageOrUpdater(prev)
+          : pageOrUpdater;
+      const newSearchParams = new URLSearchParams(searchParamsFromUrl);
+      newSearchParams.set('page', next.toString());
+      setSearchParamsFromUrl(newSearchParams, { replace: true });
+      return next;
+    });
   };
 
   return (
-    <div className='grid w-full grid-cols-2 gap-6'>
-      <PostList
-        selectedPostId={selectedPostId}
-        onSelectPost={handleSelectPost}
-        onOpenModal={(post: AdminGetPostResponse) => setModalPostId(post)}
+    <div className='flex w-full flex-col gap-6 pb-12'>
+      <PageHeader
+        title='댓글 관리'
+        description='커뮤니티에 등록된 댓글을 편집하거나 삭제하고, 더블클릭 및 필터 검색을 활용해 상세 내역을 파악할 수 있습니다.'
       />
-      <CommentList
-        key={selectedPostId ?? 'none'}
-        selectedPostId={selectedPostId}
-      />
-      <PostDetailModal
-        postId={modalPostId?.postId ?? null}
-        deletedAt={modalPostId ? (modalPostId.deletedAt ?? null) : null}
-        onClose={() => setModalPostId(null)}
-      />
+
+      <div className='flex flex-col gap-4'>
+        <CommentTable
+          searchParams={searchParams}
+          refreshKey={refreshKey}
+          currentPage={currentPage}
+          onPageChange={handlePageChange}
+        />
+      </div>
     </div>
   );
 }

--- a/src/shared/constants/sidebar-menus.ts
+++ b/src/shared/constants/sidebar-menus.ts
@@ -1,7 +1,7 @@
 import {
   // Bell,
   BookOpen,
-  // FileText,
+  FileText,
   HandCoins,
   type LucideIcon,
   User,
@@ -36,16 +36,16 @@ export const SIDEBAR_MENUS: SidebarMenu[] = [
       // },
     ],
   },
-  // {
-  //   title: '게시글 관리',
-  //   icon: FileText,
-  //   items: [
-  //     {
-  //       title: '댓글 관리',
-  //       url: PATHS.POST_COMMENTS,
-  //     },
-  //   ],
-  // },
+  {
+    title: '게시글 관리',
+    icon: FileText,
+    items: [
+      {
+        title: '댓글 관리',
+        url: PATHS.POST_COMMENTS,
+      },
+    ],
+  },
   {
     title: '시험후기',
     icon: BookOpen,


### PR DESCRIPTION
## 🔎 What is this PR?

Close #228 

- [Figma](https://www.figma.com/make/fSK0PDa49G66yl00hyfXgw/%EB%8C%93%EA%B8%80-%EB%AA%A9%EB%A1%9D-%EC%A1%B0%ED%9A%8C-%EA%B8%B0%EB%8A%A5?t=Y0rdQvOobt1hEwOs-1)
- [Notion](https://www.notion.so/snorose/1-A1-31b7ef0aa3bf8183a3c8f9141a75a033?source=copy_link)

## 🎯 변경 사항




**새로운 댓글 테이블 및 UI 개선 사항:**

* `CommentTable` 추가: 대량 선택, 액션 바, 페이지네이션 기능을 갖춘 테이블 형태의 새로운 댓글 표시 컴포넌트입니다. 새롭게 만든 상태 관리 훅과 연동되며, 데이터가 없거나 로딩 중인 상태를 지원합니다. (`src/domains/Comments/components/CommentTable.tsx`)
* `CommentBulkActionBar` 구현: 선택한 댓글들에 대해 일괄 작업(공개 여부 변경, 복구, 삭제)을 수행할 수 있는 기능을 구현하여 어드민 워크플로우를 개선했습니다. (`src/domains/Comments/components/CommentBulkActionBar.tsx`)
* `CommentTableRow` 추가: 선택 기능, 인라인 액션, 더블 클릭 필터링 기능을 포함하여 개별 댓글 행을 렌더링하는 컴포넌트입니다. (`src/domains/Comments/components/CommentTableRow.tsx`)
* `MemberInfoPopover` 도입: 닉네임을 클릭했을 때 미니 유저 프로필을 보여주는 팝오버 기능으로, 이동 및 검색 연동 기능이 포함되어 있습니다. (`src/domains/Comments/components/MemberInfoPopover.tsx`)

**데이터 패칭(Data Fetching) 및 로직:**

* `useCommentList` 훅 추가: React Query를 통해 페이지네이션이 적용된 댓글 목록을 가져오는 훅으로, 데이터 로직을 한곳으로 모았습니다. (`src/domains/Comments/hooks/useCommentList.ts`)


## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->
<img width="1512" height="863" alt="스크린샷 2026-05-23 오후 9 18 40" src="https://github.com/user-attachments/assets/4c70478f-ef2c-4cdf-bc4a-445ea573025b" />

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
