### PR TITLE
[FEAT] #233 게시글 관리 UI 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import {
   MemberPenaltyManagementPage,
   PointFreezePage,
   PostCommentPage,
+  PostManagePage,
   PushNotificationPage,
 } from '@/pages';
 
@@ -91,6 +92,10 @@ function App() {
                             <Route
                               path={PATHS.POST_COMMENTS}
                               element={<PostCommentPage />}
+                            />
+                            <Route
+                              path={PATHS.POST_MANAGE}
+                              element={<PostManagePage />}
                             />
                             <Route
                               path={PATHS.ALERTS}

--- a/src/apis/posts.ts
+++ b/src/apis/posts.ts
@@ -2,8 +2,10 @@ import { axiosInstance } from '@/shared/axios/instance';
 
 import type {
   AdminGetPostResponse,
+  AdminPostBulkDeleteResponse,
   AdminPostListResponse,
   AdminPostSearchRequest,
+  DeletePostResponse,
 } from '@/domains/Comments/types/post';
 
 // 게시글 조건 조회 api
@@ -12,7 +14,7 @@ export const searchPosts = async (
   body: AdminPostSearchRequest
 ): Promise<AdminPostListResponse['result']> => {
   const response = await axiosInstance.post('/v1/admin/posts/search', body, {
-    params: { page },
+    params: { page: page - 1 },
   });
   return response.data.result;
 };
@@ -30,5 +32,35 @@ export const getDeletedPost = async (
   postId: number
 ): Promise<AdminGetPostResponse> => {
   const response = await axiosInstance.get(`/v1/admin/posts/deleted/${postId}`);
+  return response.data.result;
+};
+
+// 게시글 삭제 api
+export const deletePost = async (
+  postId: number
+): Promise<DeletePostResponse['result']> => {
+  const response = await axiosInstance.delete(`/v1/admin/posts/${postId}`);
+  return response.data.result;
+};
+
+// 여러 게시글 선택 삭제 api
+export const bulkDeletePosts = async (
+  postIds: number[]
+): Promise<AdminPostBulkDeleteResponse['result']> => {
+  const response = await axiosInstance.delete('/v1/admin/posts', {
+    data: { postIds },
+  });
+  return response.data.result;
+};
+
+// 게시글 노출/숨김 일괄 업데이트 api
+export const updatePostVisibility = async (
+  postIds: number[],
+  isVisible: boolean
+): Promise<string> => {
+  const response = await axiosInstance.patch(`/v1/admin/posts/visibility`, {
+    postIds,
+    isVisible,
+  });
   return response.data.result;
 };

--- a/src/domains/Comments/components/PostBulkActionBar.tsx
+++ b/src/domains/Comments/components/PostBulkActionBar.tsx
@@ -1,0 +1,70 @@
+import { Eye, EyeOff, RotateCcw, Trash2 } from 'lucide-react';
+
+import { Button } from '@/shared/components/ui';
+
+interface PostBulkActionBarProps {
+  selectedCount: number;
+  isVisibilityPending: boolean;
+  isDeletePending: boolean;
+  onBulkVisibility: (visible: boolean) => void;
+  onBulkRestore: () => void;
+  onBulkDelete: () => void;
+}
+
+export default function PostBulkActionBar({
+  selectedCount,
+  isVisibilityPending,
+  isDeletePending,
+  onBulkVisibility,
+  onBulkRestore,
+  onBulkDelete,
+}: PostBulkActionBarProps) {
+  if (selectedCount === 0) return null;
+
+  return (
+    <div className='flex items-center justify-between rounded-lg border border-red-200 bg-red-50/50 px-4 py-3 shadow-sm'>
+      <span className='text-sm font-medium text-red-800'>
+        선택된 <strong className='text-red-700'>{selectedCount}</strong>개의
+        게시글에 대해 일괄 동작을 적용할 수 있습니다.
+      </span>
+      <div className='flex flex-wrap items-center gap-2'>
+        <Button
+          variant='outline'
+          size='sm'
+          className='flex h-8 items-center gap-1 border-gray-300 bg-white text-xs text-gray-700 hover:bg-gray-50'
+          disabled={isVisibilityPending}
+          onClick={() => onBulkVisibility(true)}
+        >
+          <Eye className='h-3.5 w-3.5 text-blue-600' /> 비공개 해제
+        </Button>
+        <Button
+          variant='outline'
+          size='sm'
+          className='flex h-8 items-center gap-1 border-gray-300 bg-white text-xs text-gray-700 hover:bg-gray-50'
+          disabled={isVisibilityPending}
+          onClick={() => onBulkVisibility(false)}
+        >
+          <EyeOff className='h-3.5 w-3.5 text-gray-500' /> 비공개
+        </Button>
+        <Button
+          variant='outline'
+          size='sm'
+          className='flex h-8 items-center gap-1 border-gray-300 bg-white text-xs text-gray-700 hover:bg-gray-50'
+          disabled={isVisibilityPending}
+          onClick={onBulkRestore}
+        >
+          <RotateCcw className='text-green-650 h-3.5 w-3.5' /> 복구
+        </Button>
+        <Button
+          variant='destructive'
+          size='sm'
+          className='flex h-8 items-center gap-1 bg-red-600 text-xs hover:bg-red-700'
+          disabled={isDeletePending}
+          onClick={onBulkDelete}
+        >
+          <Trash2 className='h-3.5 w-3.5' /> 삭제
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/domains/Comments/components/PostTable.tsx
+++ b/src/domains/Comments/components/PostTable.tsx
@@ -1,0 +1,173 @@
+import { Loader2 } from 'lucide-react';
+
+import { Table } from '@/shared/components/ui';
+
+import { ExamReviewTablePagination } from '@/domains/Reviews/components';
+
+import { usePostTableState } from '../hooks/usePostTableState';
+import PostBulkActionBar from './PostBulkActionBar';
+import PostTableRow from './PostTableRow';
+
+interface PostTableProps {
+  searchParams?: {
+    encryptedUserId?: string;
+    boardId?: number;
+    isVisible?: boolean;
+    isKeywordExist?: boolean;
+    startDate?: string;
+    endDate?: string;
+    status?: string;
+  };
+  refreshKey?: number;
+  currentPage: number;
+  onPageChange: (page: number | ((prev: number) => number)) => void;
+}
+
+export default function PostTable({
+  searchParams = {},
+  refreshKey,
+  currentPage,
+  onPageChange,
+}: PostTableProps) {
+  const {
+    posts,
+    isLoading,
+    selectedIds,
+    setSelectedIds,
+    isAllSelected,
+    selectAllRef,
+    handleSelectAll,
+    activePopoverId,
+    setActivePopoverId,
+    popoverUser,
+    isUserLoading,
+    handleNicknameClick,
+    handleBulkDelete,
+    handleBulkVisibility,
+    handleBulkRestore,
+    handleSingleDelete,
+    isDeletePending,
+    isVisibilityPending,
+    hasNext,
+  } = usePostTableState({
+    searchParams,
+    refreshKey,
+    currentPage,
+  });
+
+  const isEmpty = !isLoading && posts.length === 0;
+
+  return (
+    <div
+      className='flex flex-col gap-3'
+      onClick={() => setActivePopoverId(null)}
+    >
+      <PostBulkActionBar
+        selectedCount={selectedIds.length}
+        isVisibilityPending={isVisibilityPending}
+        isDeletePending={isDeletePending}
+        onBulkVisibility={handleBulkVisibility}
+        onBulkRestore={handleBulkRestore}
+        onBulkDelete={handleBulkDelete}
+      />
+
+      <div className='overflow-hidden rounded-md border border-gray-200 bg-white shadow-sm'>
+        <div className='w-full overflow-x-auto'>
+          <Table className='w-full min-w-[1200px] table-fixed text-[13px]'>
+            <Table.Header className='h-[42px] border-b border-gray-200 bg-gray-50 font-semibold text-gray-700'>
+              <Table.Head
+                style={{ width: '40px' }}
+                className='px-3 text-center'
+              >
+                <input
+                  type='checkbox'
+                  ref={selectAllRef}
+                  checked={isAllSelected}
+                  onChange={handleSelectAll}
+                  className='cursor-pointer rounded border-gray-300'
+                />
+              </Table.Head>
+              <Table.Head style={{ width: '180px' }} className='px-3 text-xs'>
+                게시일
+              </Table.Head>
+              <Table.Head style={{ width: '110px' }} className='px-3 text-xs'>
+                게시판
+              </Table.Head>
+              <Table.Head style={{ width: '120px' }} className='px-3 text-xs'>
+                닉네임
+              </Table.Head>
+              <Table.Head style={{ width: '200px' }} className='px-3 text-xs'>
+                제목
+              </Table.Head>
+              <Table.Head style={{ width: '330px' }} className='px-3 text-xs'>
+                내용
+              </Table.Head>
+              <Table.Head
+                style={{ width: '120px' }}
+                className='px-3 text-center text-xs'
+              >
+                상태
+              </Table.Head>
+              <Table.Head
+                style={{ width: '100px' }}
+                className='px-3 text-center text-xs'
+              >
+                의심 키워드
+              </Table.Head>
+            </Table.Header>
+
+            <Table.Body>
+              {isLoading ? (
+                <Table.Row>
+                  <Table.Cell colSpan={8} className='h-48 text-center'>
+                    <div className='flex items-center justify-center gap-2 text-gray-500'>
+                      <Loader2 className='h-5 w-5 animate-spin text-blue-600' />
+                      <span>게시글 데이터를 불러오는 중입니다...</span>
+                    </div>
+                  </Table.Cell>
+                </Table.Row>
+              ) : isEmpty ? (
+                <Table.Row>
+                  <Table.Cell
+                    colSpan={8}
+                    className='h-48 text-center text-sm text-gray-400'
+                  >
+                    등록된 게시글이 없거나 검색 결과가 존재하지 않습니다.
+                  </Table.Cell>
+                </Table.Row>
+              ) : (
+                posts.map((post) => (
+                  <PostTableRow
+                    key={post.postId}
+                    post={post}
+                    isSelected={selectedIds.includes(post.postId)}
+                    onSelectToggle={(id) => {
+                      setSelectedIds((prev) =>
+                        prev.includes(id)
+                          ? prev.filter((item) => item !== id)
+                          : [...prev, id]
+                      );
+                    }}
+                    activePopoverId={activePopoverId}
+                    onNicknameClick={handleNicknameClick}
+                    popoverUser={popoverUser}
+                    isUserLoading={isUserLoading}
+                    onClosePopover={() => setActivePopoverId(null)}
+                    onPageChange={onPageChange}
+                    onSingleDelete={handleSingleDelete}
+                  />
+                ))
+              )}
+            </Table.Body>
+          </Table>
+        </div>
+      </div>
+
+      <ExamReviewTablePagination
+        currentPage={currentPage}
+        onPageChange={onPageChange}
+        hasNext={hasNext}
+      />
+    </div>
+  );
+}

--- a/src/domains/Comments/components/PostTableRow.tsx
+++ b/src/domains/Comments/components/PostTableRow.tsx
@@ -1,0 +1,192 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { Badge, Table } from '@/shared/components/ui';
+import { cn } from '@/shared/lib';
+import type { MemberInfo } from '@/shared/types';
+import { formatDateTimeToMinutes } from '@/shared/utils';
+import {
+  getBoardBadge,
+  getPostStatus,
+  getRowStyle,
+  getStatusBadgeClass,
+} from '@/shared/utils/postCommentUtils';
+
+import type { AdminGetPostResponse } from '../types/post';
+import MemberInfoPopover from './MemberInfoPopover';
+
+interface PostTableRowProps {
+  post: AdminGetPostResponse;
+  isSelected: boolean;
+  onSelectToggle: (id: number) => void;
+  activePopoverId: number | null;
+  onNicknameClick: (e: React.MouseEvent, post: AdminGetPostResponse) => void;
+  popoverUser: MemberInfo | null;
+  isUserLoading: boolean;
+  onClosePopover: () => void;
+  onPageChange: (page: number | ((prev: number) => number)) => void;
+  onSingleDelete: (postId: number) => void;
+}
+
+export default function PostTableRow({
+  post,
+  isSelected,
+  onSelectToggle,
+  activePopoverId,
+  onNicknameClick,
+  popoverUser,
+  isUserLoading,
+  onClosePopover,
+  onPageChange,
+  onSingleDelete,
+}: PostTableRowProps) {
+  const navigate = useNavigate();
+  const status = getPostStatus(post);
+  const rowStyle = getRowStyle(status);
+  const board = getBoardBadge(post.boardId);
+
+  return (
+    <Table.Row
+      className={cn(
+        'border-b border-gray-100 last:border-0 [&_td]:h-[54px]',
+        rowStyle
+      )}
+    >
+      {/* Checkbox */}
+      <Table.Cell
+        className='px-3 text-center'
+        onClick={(e) => e.stopPropagation()}
+      >
+        <input
+          type='checkbox'
+          checked={isSelected}
+          onChange={(e) => {
+            e.stopPropagation();
+            onSelectToggle(post.postId);
+          }}
+          className='cursor-pointer rounded border-gray-300'
+        />
+      </Table.Cell>
+
+      {/* 게시일 */}
+      <Table.Cell className='px-3 font-mono text-gray-600'>
+        {(() => {
+          const created = formatDateTimeToMinutes(post.createdAt).replace(
+            'T',
+            ' '
+          );
+          if (status !== '정상') {
+            let changeDateStr = '';
+            let label = '';
+
+            if (status === '관리자삭제' && post.deletedAt) {
+              changeDateStr = formatDateTimeToMinutes(post.deletedAt).replace(
+                'T',
+                ' '
+              );
+              label = '관리자 삭제';
+            } else if (status === '관리자비공개' && post.updatedAt) {
+              changeDateStr = formatDateTimeToMinutes(post.updatedAt).replace(
+                'T',
+                ' '
+              );
+              label = '관리자 비공개';
+            } else if (status.startsWith('신고누적') && post.updatedAt) {
+              changeDateStr = formatDateTimeToMinutes(post.updatedAt).replace(
+                'T',
+                ' '
+              );
+              label = '신고누적';
+            }
+
+            if (changeDateStr) {
+              return (
+                <div className='flex flex-col leading-tight'>
+                  <span className='font-semibold'>{created}</span>
+                  <span className='text-[10px] font-medium text-gray-400'>
+                    ({label}: {changeDateStr})
+                  </span>
+                </div>
+              );
+            }
+          }
+          return created;
+        })()}
+      </Table.Cell>
+
+      {/* 게시판 */}
+      <Table.Cell className='px-3'>
+        <Badge className={board.className}>{board.name}</Badge>
+      </Table.Cell>
+
+      {/* 닉네임 */}
+      <Table.Cell
+        className='relative cursor-pointer px-3 font-bold text-gray-900 select-none'
+        onClick={(e) => onNicknameClick(e, post)}
+      >
+        <div className='truncate transition-colors hover:text-blue-700 hover:underline'>
+          {post.userDisplay || '익명송이'}
+        </div>
+        {activePopoverId === post.postId && (
+          <MemberInfoPopover
+            encryptedUserId={post.encryptedUserId}
+            popoverUser={popoverUser}
+            isUserLoading={isUserLoading}
+            onClose={onClosePopover}
+            onPageChange={onPageChange}
+          />
+        )}
+      </Table.Cell>
+
+      {/* 제목 */}
+      <Table.Cell
+        className='max-w-[200px] cursor-pointer truncate px-3 py-1 font-bold text-gray-900 select-text'
+        onDoubleClick={(e) => {
+          e.stopPropagation();
+          navigate(`/posts/${post.postId}`);
+        }}
+        title={post.title}
+      >
+        {post.title}
+      </Table.Cell>
+
+      {/* 내용 */}
+      <Table.Cell
+        className='max-w-[330px] cursor-pointer truncate px-3 py-1 text-gray-500 select-text'
+        onDoubleClick={(e) => {
+          e.stopPropagation();
+          navigate(`/posts/${post.postId}`);
+        }}
+        title={post.content || '-'}
+      >
+        {post.content || '-'}
+      </Table.Cell>
+
+      {/* 상태 */}
+      <Table.Cell className='px-3 text-center'>
+        <Badge
+          className={cn(getStatusBadgeClass(status), 'cursor-pointer')}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (status !== '관리자삭제') {
+              onSingleDelete(post.postId);
+            }
+          }}
+        >
+          {status}
+        </Badge>
+      </Table.Cell>
+
+      {/* 의심 키워드 */}
+      <Table.Cell className='px-3 text-center'>
+        {post.isKeywordExist ? (
+          <Badge className='rounded border-none bg-[#F5F3FF] px-2 py-0.5 text-[11px] font-bold text-[#7C3AED] hover:bg-[#F5F3FF]'>
+            포함
+          </Badge>
+        ) : (
+          <span className='font-mono text-gray-300'>-</span>
+        )}
+      </Table.Cell>
+    </Table.Row>
+  );
+}

--- a/src/domains/Comments/hooks/useBulkDeletePost.ts
+++ b/src/domains/Comments/hooks/useBulkDeletePost.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { bulkDeletePosts } from '@/apis';
+
+export const useBulkDeletePost = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (postIds: number[]) => bulkDeletePosts(postIds),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['posts'] });
+    },
+    onError: (error) => {
+      console.error('게시글 일괄 삭제 중 오류 발생:', error);
+    },
+  });
+};

--- a/src/domains/Comments/hooks/useDeletePost.ts
+++ b/src/domains/Comments/hooks/useDeletePost.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { deletePost } from '@/apis';
+
+export const useDeletePost = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (postId: number) => deletePost(postId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['posts'] });
+    },
+    onError: (error) => {
+      console.error('게시글 삭제 중 오류 발생:', error);
+    },
+  });
+};

--- a/src/domains/Comments/hooks/usePostList.ts
+++ b/src/domains/Comments/hooks/usePostList.ts
@@ -33,5 +33,6 @@ export const usePostList = (params: usePostListParams) => {
     error: normalResult.error,
     hasNext: normalResult.data?.hasNext,
     totalPage: normalResult.data?.totalPage,
+    refetch: normalResult.refetch,
   };
 };

--- a/src/domains/Comments/hooks/usePostTableState.ts
+++ b/src/domains/Comments/hooks/usePostTableState.ts
@@ -1,0 +1,273 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { toast } from 'sonner';
+
+import type { MemberInfo } from '@/shared/types';
+import { getPostStatus } from '@/shared/utils/postCommentUtils';
+
+import { extractFirstSearchMember } from '@/domains/MemberInfo/utils/memberDirectory';
+
+import { searchUsersAPI } from '@/apis/users';
+
+import type { AdminGetPostResponse } from '../types/post';
+import { useBulkDeletePost } from './useBulkDeletePost';
+import { useDeletePost } from './useDeletePost';
+import { usePostList } from './usePostList';
+import { useUpdatePostVisibility } from './useUpdatePostVisibility';
+
+interface UsePostTableStateProps {
+  searchParams: {
+    encryptedUserId?: string;
+    boardId?: number;
+    isVisible?: boolean;
+    isKeywordExist?: boolean;
+    startDate?: string;
+    endDate?: string;
+    status?: string;
+  };
+  refreshKey?: number;
+  currentPage: number;
+}
+
+export function usePostTableState({
+  searchParams,
+  refreshKey,
+  currentPage,
+}: UsePostTableStateProps) {
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [sortBy] = useState<'reportCount' | 'createdAt'>('createdAt');
+  const [sortDir] = useState<'asc' | 'desc'>('desc');
+
+  // 닉네임 클릭 팝오버 상태
+  const [activePopoverId, setActivePopoverId] = useState<number | null>(null);
+  const [popoverUser, setPopoverUser] = useState<MemberInfo | null>(null);
+  const [isUserLoading, setIsUserLoading] = useState(false);
+
+  // 검색 조건 변경 시 선택 초기화 및 팝오버 닫기
+  useEffect(() => {
+    setSelectedIds([]);
+    setActivePopoverId(null);
+  }, [
+    searchParams.encryptedUserId,
+    searchParams.boardId,
+    searchParams.isVisible,
+    searchParams.isKeywordExist,
+    searchParams.startDate,
+    searchParams.endDate,
+    searchParams.status,
+  ]);
+
+  const {
+    data: rawPosts,
+    isLoading,
+    error,
+    hasNext,
+    refetch,
+  } = usePostList({
+    page: currentPage,
+    body: {
+      encryptedUserId: searchParams.encryptedUserId,
+      boardId: searchParams.boardId,
+      isVisible: searchParams.isVisible,
+      isKeywordExist: searchParams.isKeywordExist,
+      startDate: searchParams.startDate,
+      endDate: searchParams.endDate,
+    },
+  });
+
+  useEffect(() => {
+    if (refreshKey) void refetch();
+  }, [refreshKey, refetch]);
+
+  const posts = useMemo<AdminGetPostResponse[]>(() => {
+    let list = rawPosts ?? [];
+
+    // 상태 필터링 (클라이언트 보완 필터)
+    if (searchParams.status && searchParams.status !== '전체') {
+      list = list.filter((p) => getPostStatus(p) === searchParams.status);
+    }
+
+    return [...list].sort((a, b) => {
+      if (sortBy === 'reportCount') {
+        return sortDir === 'asc'
+          ? a.reportCount - b.reportCount
+          : b.reportCount - a.reportCount;
+      }
+      const ta = new Date(a.createdAt).getTime();
+      const tb = new Date(b.createdAt).getTime();
+      return sortDir === 'asc' ? ta - tb : tb - ta;
+    });
+  }, [rawPosts, sortBy, sortDir, searchParams.status]);
+
+  const { mutate: bulkDelete, isPending: isDeletePending } =
+    useBulkDeletePost();
+  const { mutate: singleDelete } = useDeletePost();
+  const { mutate: bulkVisibility, isPending: isVisibilityPending } =
+    useUpdatePostVisibility();
+
+  const handleBulkDelete = () => {
+    if (selectedIds.length === 0) return;
+
+    const message = `선택한 ${selectedIds.length}개의 게시글을 삭제하시겠습니까?`;
+    if (!window.confirm(message)) return;
+
+    // 삭제 시 댓글도 일괄 삭제 여부 팝업
+    const deleteComments = window.confirm('댓글도 모두 삭제하시겠습니까?');
+
+    bulkDelete(selectedIds, {
+      onSuccess: (res) => {
+        const deletedCount = res?.deletedCount ?? selectedIds.length;
+        if (deleteComments) {
+          toast.success(
+            `${deletedCount}개의 게시글과 관련 댓글이 삭제되었습니다.`
+          );
+        } else {
+          toast.success(`${deletedCount}개의 게시글이 삭제되었습니다.`);
+        }
+        setSelectedIds([]);
+      },
+      onError: () => toast.error('게시글 일괄 삭제 중 오류가 발생했습니다.'),
+    });
+  };
+
+  const handleBulkVisibility = (isVisible: boolean) => {
+    if (selectedIds.length === 0) return;
+    bulkVisibility(
+      { postIds: selectedIds, isVisible },
+      {
+        onSuccess: () => {
+          toast.success(
+            isVisible
+              ? '선택한 게시글의 비공개가 해제되었습니다.'
+              : '선택한 게시글이 비공개 처리되었습니다.'
+          );
+          setSelectedIds([]);
+        },
+        onError: () =>
+          toast.error('노출 상태 일괄 변경 중 오류가 발생했습니다.'),
+      }
+    );
+  };
+
+  const handleBulkRestore = () => {
+    if (selectedIds.length === 0) return;
+    bulkVisibility(
+      { postIds: selectedIds, isVisible: true },
+      {
+        onSuccess: () => {
+          toast.success('선택한 게시글과 댓글이 성공적으로 복구되었습니다.');
+          setSelectedIds([]);
+        },
+        onError: () => toast.error('게시글 복구 중 오류가 발생했습니다.'),
+      }
+    );
+  };
+
+  const handleSingleDelete = (postId: number) => {
+    if (!window.confirm('이 게시글을 삭제하시겠습니까?')) return;
+
+    singleDelete(postId, {
+      onSuccess: () => {
+        toast.success('게시글이 삭제되었습니다.');
+        setSelectedIds((prev) => prev.filter((id) => id !== postId));
+      },
+      onError: () => toast.error('게시글 삭제 중 오류가 발생했습니다.'),
+    });
+  };
+
+  // 체크박스 제어
+  const allPostIds = posts.map((p) => p.postId);
+  const isAllSelected =
+    allPostIds.length > 0 && allPostIds.every((id) => selectedIds.includes(id));
+  const isSomeSelected =
+    allPostIds.some((id) => selectedIds.includes(id)) && !isAllSelected;
+
+  const selectAllRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (selectAllRef.current)
+      selectAllRef.current.indeterminate = isSomeSelected;
+  }, [isSomeSelected]);
+
+  const handleSelectAll = () => {
+    if (isAllSelected) {
+      setSelectedIds((prev) => prev.filter((id) => !allPostIds.includes(id)));
+    } else {
+      setSelectedIds((prev) => Array.from(new Set([...prev, ...allPostIds])));
+    }
+  };
+
+  // 닉네임 클릭 핸들러
+  const handleNicknameClick = async (
+    e: React.MouseEvent,
+    post: AdminGetPostResponse
+  ) => {
+    e.stopPropagation();
+
+    if (activePopoverId === post.postId) {
+      setActivePopoverId(null);
+      setPopoverUser(null);
+      return;
+    }
+
+    setActivePopoverId(post.postId);
+    setPopoverUser(null);
+    setIsUserLoading(true);
+
+    try {
+      const display = post.userDisplay || '익명';
+      const res = await searchUsersAPI(display);
+      const member = extractFirstSearchMember(res?.result);
+      if (member) {
+        setPopoverUser(member);
+      } else {
+        setPopoverUser({
+          encryptedUserId: post.encryptedUserId,
+          loginId: '정보 없음',
+          userName: display,
+          email: '',
+          nickname: display,
+          userRoleId: 1,
+          studentNumber: '정보 없음',
+          major: '정보 없음',
+          birthday: '',
+          pointBalance: 0,
+          createdAt: '',
+          authenticatedAt: null,
+          totalWarningCount: 0,
+          isBlacklist: false,
+          blacklistStartDate: null,
+          blacklistEndDate: null,
+        });
+      }
+    } catch (err) {
+      console.error(err);
+      toast.error('회원 상세 조회에 실패했습니다.');
+    } finally {
+      setIsUserLoading(false);
+    }
+  };
+
+  return {
+    posts,
+    isLoading,
+    error,
+    selectedIds,
+    setSelectedIds,
+    isAllSelected,
+    isSomeSelected,
+    selectAllRef,
+    handleSelectAll,
+    activePopoverId,
+    setActivePopoverId,
+    popoverUser,
+    isUserLoading,
+    handleNicknameClick,
+    handleBulkDelete,
+    handleBulkVisibility,
+    handleBulkRestore,
+    handleSingleDelete,
+    isDeletePending,
+    isVisibilityPending,
+    hasNext: hasNext ?? posts.length > 0, // Fallback if query pagination hasNext is needed
+  };
+}

--- a/src/domains/Comments/hooks/useUpdatePostVisibility.ts
+++ b/src/domains/Comments/hooks/useUpdatePostVisibility.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { updatePostVisibility } from '@/apis';
+
+export const useUpdatePostVisibility = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      postIds,
+      isVisible,
+    }: {
+      postIds: number[];
+      isVisible: boolean;
+    }) => updatePostVisibility(postIds, isVisible),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['posts'] });
+    },
+    onError: (error) => {
+      console.error('게시글 상태 변경 중 오류 발생:', error);
+    },
+  });
+};

--- a/src/domains/Comments/utils/commentUtils.ts
+++ b/src/domains/Comments/utils/commentUtils.ts
@@ -1,77 +1,12 @@
 import type { AdminCommentResponse } from '../types/comment';
 
-// 게시판 이름 매핑 및 배지 스타일 (함박눈방, 첫눈온방, 만년설방, 시험후기)
-export const getBoardBadge = (boardId: number) => {
-  const mapping: Record<number, { name: string; className: string }> = {
-    1: {
-      name: '함박눈방',
-      className:
-        'bg-[#F3E8FF] text-[#6B21A8] hover:bg-[#F3E8FF] border-none font-semibold px-2.5 py-0.5 rounded-full',
-    },
-    11: {
-      name: '함박눈방',
-      className:
-        'bg-[#F3E8FF] text-[#6B21A8] hover:bg-[#F3E8FF] border-none font-semibold px-2.5 py-0.5 rounded-full',
-    },
-    21: {
-      name: '함박눈방',
-      className:
-        'bg-[#F3E8FF] text-[#6B21A8] hover:bg-[#F3E8FF] border-none font-semibold px-2.5 py-0.5 rounded-full',
-    },
-    2: {
-      name: '첫눈온방',
-      className:
-        'bg-[#E0F2FE] text-[#0369A1] hover:bg-[#E0F2FE] border-none font-semibold px-2.5 py-0.5 rounded-full',
-    },
-    12: {
-      name: '첫눈온방',
-      className:
-        'bg-[#E0F2FE] text-[#0369A1] hover:bg-[#E0F2FE] border-none font-semibold px-2.5 py-0.5 rounded-full',
-    },
-    22: {
-      name: '첫눈온방',
-      className:
-        'bg-[#E0F2FE] text-[#0369A1] hover:bg-[#E0F2FE] border-none font-semibold px-2.5 py-0.5 rounded-full',
-    },
-    3: {
-      name: '만년설방',
-      className:
-        'bg-[#E0F7FA] text-[#006064] hover:bg-[#E0F7FA] border-none font-semibold px-2.5 py-0.5 rounded-full',
-    },
-    13: {
-      name: '만년설방',
-      className:
-        'bg-[#E0F7FA] text-[#006064] hover:bg-[#E0F7FA] border-none font-semibold px-2.5 py-0.5 rounded-full',
-    },
-    23: {
-      name: '만년설방',
-      className:
-        'bg-[#E0F7FA] text-[#006064] hover:bg-[#E0F7FA] border-none font-semibold px-2.5 py-0.5 rounded-full',
-    },
-    4: {
-      name: '시험후기',
-      className:
-        'bg-[#FCE7F3] text-[#9D174D] hover:bg-[#FCE7F3] border-none font-semibold px-2.5 py-0.5 rounded-full',
-    },
-    14: {
-      name: '시험후기',
-      className:
-        'bg-[#FCE7F3] text-[#9D174D] hover:bg-[#FCE7F3] border-none font-semibold px-2.5 py-0.5 rounded-full',
-    },
-    24: {
-      name: '시험후기',
-      className:
-        'bg-[#FCE7F3] text-[#9D174D] hover:bg-[#FCE7F3] border-none font-semibold px-2.5 py-0.5 rounded-full',
-    },
-  };
-  return (
-    mapping[boardId] || {
-      name: `게시판 ${boardId}`,
-      className:
-        'bg-gray-100 text-gray-700 font-semibold px-2 py-0.5 rounded-full',
-    }
-  );
-};
+export {
+  formatCommentId,
+  formatPostId,
+  getBoardBadge,
+  getRowStyle,
+  getStatusBadgeClass,
+} from '@/shared/utils/postCommentUtils';
 
 // 2. 댓글 상태 분류 헬퍼 함수
 export const getCommentStatus = (comment: AdminCommentResponse): string => {
@@ -100,50 +35,3 @@ export const getCommentStatus = (comment: AdminCommentResponse): string => {
   }
   return '정상';
 };
-
-// 상태별 Row 배경색 매핑 함수
-export const getRowStyle = (status: string) => {
-  switch (status) {
-    case '신고누적':
-      return 'bg-[#FFF9E6] hover:bg-[#FFF2CC] border-b border-gray-100 transition-colors text-yellow-950';
-    case '삭제됨':
-      return 'bg-[#FFF0F0] hover:bg-[#FFE3E3] border-b border-gray-100 transition-colors text-gray-500 opacity-90';
-    case '관리자삭제':
-      return 'bg-[#FFEBEB] hover:bg-[#FFD6D6] border-b border-gray-100 transition-colors text-red-950';
-    case '관리자비공개':
-      return 'bg-[#F5F7FA] hover:bg-[#E4E8ED] border-b border-gray-100 transition-colors text-slate-900';
-    case '복구':
-      return 'bg-[#EBF7EE] hover:bg-[#D5EEDC] border-b border-gray-100 transition-colors text-green-950';
-    case '비공개해제':
-      return 'bg-[#EBF3FC] hover:bg-[#D5E4F9] border-b border-gray-100 transition-colors text-blue-950';
-    default:
-      return 'bg-white hover:bg-gray-50/50 border-b border-gray-100 text-gray-800';
-  }
-};
-
-// 상태별 배지 스타일 매핑 함수
-export const getStatusBadgeClass = (status: string) => {
-  switch (status) {
-    case '정상':
-      return 'bg-[#EBF7EE] text-[#2A7E3E] border-[#B2E2BD] hover:bg-[#EBF7EE] font-semibold text-[11px] px-2 py-0.5 rounded border';
-    case '삭제됨':
-      return 'bg-[#FFF0F0] text-[#D32F2F] border-[#FFCDD2] hover:bg-[#FFF0F0] font-semibold text-[11px] px-2 py-0.5 rounded border';
-    case '관리자삭제':
-      return 'bg-[#FFEBEB] text-[#C62828] border-[#EF9A9A] hover:bg-[#FFEBEB] font-semibold text-[11px] px-2 py-0.5 rounded border';
-    case '복구':
-      return 'bg-[#EBF7EE] text-[#2A7E3E] border-[#B2E2BD] hover:bg-[#EBF7EE] font-semibold text-[11px] px-2 py-0.5 rounded border';
-    case '신고누적':
-      return 'bg-[#FFF3E0] text-[#E65100] border-[#FFE0B2] hover:bg-[#FFF3E0] font-semibold text-[11px] px-2 py-0.5 rounded border';
-    case '관리자비공개':
-      return 'bg-[#ECEFF1] text-[#37474F] border-[#CFD8DC] hover:bg-[#ECEFF1] font-semibold text-[11px] px-2 py-0.5 rounded border';
-    case '비공개해제':
-      return 'bg-[#E3F2FD] text-[#0D47A1] border-[#BBDEFB] hover:bg-[#E3F2FD] font-semibold text-[11px] px-2 py-0.5 rounded border';
-    default:
-      return 'bg-gray-50 text-gray-600 border-gray-200 hover:bg-gray-50 font-semibold text-[11px] px-2 py-0.5 rounded border';
-  }
-};
-
-// ID 포맷터
-export const formatCommentId = (id: number) =>
-  `C${String(id).padStart(3, '0')}`;
-export const formatPostId = (id: number) => `P${String(id).padStart(3, '0')}`;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -8,5 +8,6 @@ export { default as ExcelPointUploadPage } from './points/ExcelPointUploadPage';
 export { default as PointFreezePage } from './points/PointFreezePage';
 export { default as PointMultiplePage } from './points/PointMultiplePage';
 export { default as PostCommentPage } from './posts/PostCommentPage';
+export { default as PostManagePage } from './posts/PostManagePage';
 export { default as ExamReviewPage } from './reviews/ExamReviewPage';
 export { default as ExamReviewPeriodPage } from './reviews/ExamReviewPeriodPage';

--- a/src/pages/posts/PostManagePage.tsx
+++ b/src/pages/posts/PostManagePage.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import { PageHeader } from '@/shared/components';
+
+import PostTable from '@/domains/Comments/components/PostTable';
+
+export default function PostManagePage() {
+  const [searchParamsFromUrl, setSearchParamsFromUrl] = useSearchParams();
+  const [refreshKey] = useState(0);
+  const [searchParams, setSearchParams] = useState<{
+    encryptedUserId?: string;
+    boardId?: number;
+    isVisible?: boolean;
+    isKeywordExist?: boolean;
+    startDate?: string;
+    endDate?: string;
+    status?: string;
+  }>({});
+
+  // URL에서 페이지 번호 복원
+  const currentPageFromUrl = parseInt(
+    searchParamsFromUrl.get('page') || '1',
+    10
+  );
+  const [currentPage, setCurrentPage] = useState<number>(
+    currentPageFromUrl || 1
+  );
+
+  // URL의 페이지 번호가 변경되면 state 업데이트
+  useEffect(() => {
+    const pageFromUrl = parseInt(searchParamsFromUrl.get('page') || '1', 10);
+    if (pageFromUrl !== currentPage) {
+      setCurrentPage(pageFromUrl);
+    }
+  }, [searchParamsFromUrl, currentPage]);
+
+  // URL에서 검색 옵션들 복원
+  useEffect(() => {
+    const params: typeof searchParams = {};
+
+    const encryptedUserId = searchParamsFromUrl.get('encryptedUserId');
+    if (encryptedUserId) params.encryptedUserId = encryptedUserId;
+
+    const boardId = searchParamsFromUrl.get('boardId');
+    if (boardId) {
+      const parsed = parseInt(boardId, 10);
+      if (!isNaN(parsed)) params.boardId = parsed;
+    }
+
+    const isVisible = searchParamsFromUrl.get('isVisible');
+    if (isVisible === 'true') {
+      params.isVisible = true;
+    } else if (isVisible === 'false') {
+      params.isVisible = false;
+    }
+
+    const isKeywordExist = searchParamsFromUrl.get('isKeywordExist');
+    if (isKeywordExist === 'true') {
+      params.isKeywordExist = true;
+    } else if (isKeywordExist === 'false') {
+      params.isKeywordExist = false;
+    }
+
+    const status = searchParamsFromUrl.get('status');
+    if (status) params.status = status;
+
+    const startDate = searchParamsFromUrl.get('startDate');
+    if (startDate) params.startDate = startDate;
+
+    const endDate = searchParamsFromUrl.get('endDate');
+    if (endDate) params.endDate = endDate;
+
+    setSearchParams(params);
+  }, [searchParamsFromUrl]);
+
+  const handlePageChange = (
+    pageOrUpdater: number | ((prev: number) => number)
+  ) => {
+    setCurrentPage((prev) => {
+      const next =
+        typeof pageOrUpdater === 'function'
+          ? pageOrUpdater(prev)
+          : pageOrUpdater;
+      const newSearchParams = new URLSearchParams(searchParamsFromUrl);
+      newSearchParams.set('page', next.toString());
+      setSearchParamsFromUrl(newSearchParams, { replace: true });
+      return next;
+    });
+  };
+
+  return (
+    <div className='flex w-full flex-col gap-6 pb-12'>
+      <PageHeader
+        title='게시글 관리'
+        description='커뮤니티에 등록된 게시글을 편집하거나 삭제하고, 더블클릭 및 필터 검색을 활용해 상세 내역을 파악할 수 있습니다.'
+      />
+
+      <div className='flex flex-col gap-4'>
+        <PostTable
+          searchParams={searchParams}
+          refreshKey={refreshKey}
+          currentPage={currentPage}
+          onPageChange={handlePageChange}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/shared/constants/paths.ts
+++ b/src/shared/constants/paths.ts
@@ -2,6 +2,7 @@ export const PATHS = {
   HOME: '/',
   LOGIN: '/login',
   POST_COMMENTS: '/posts/comments',
+  POST_MANAGE: '/posts/manage',
   MEMBER_INFO: '/member/info',
   MEMBER_PENALTY: '/member/penalty',
   REVIEW_EXAM: '/reviews/exam',

--- a/src/shared/constants/sidebar-menus.ts
+++ b/src/shared/constants/sidebar-menus.ts
@@ -41,6 +41,10 @@ export const SIDEBAR_MENUS: SidebarMenu[] = [
     icon: FileText,
     items: [
       {
+        title: '게시글 관리',
+        url: PATHS.POST_MANAGE,
+      },
+      {
         title: '댓글 관리',
         url: PATHS.POST_COMMENTS,
       },

--- a/src/shared/utils/postCommentUtils.ts
+++ b/src/shared/utils/postCommentUtils.ts
@@ -1,0 +1,139 @@
+// 게시판 이름 매핑 및 배지 스타일 (함박눈방, 첫눈온방, 만년설방, 시험후기)
+export const getBoardBadge = (boardId: number) => {
+  const mapping: Record<number, { name: string; className: string }> = {
+    1: {
+      name: '함박눈방',
+      className:
+        'bg-[#F3E8FF] text-[#6B21A8] hover:bg-[#F3E8FF] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    11: {
+      name: '함박눈방',
+      className:
+        'bg-[#F3E8FF] text-[#6B21A8] hover:bg-[#F3E8FF] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    21: {
+      name: '함박눈방',
+      className:
+        'bg-[#F3E8FF] text-[#6B21A8] hover:bg-[#F3E8FF] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    2: {
+      name: '첫눈온방',
+      className:
+        'bg-[#E0F2FE] text-[#0369A1] hover:bg-[#E0F2FE] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    12: {
+      name: '첫눈온방',
+      className:
+        'bg-[#E0F2FE] text-[#0369A1] hover:bg-[#E0F2FE] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    22: {
+      name: '첫눈온방',
+      className:
+        'bg-[#E0F2FE] text-[#0369A1] hover:bg-[#E0F2FE] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    3: {
+      name: '만년설방',
+      className:
+        'bg-[#E0F7FA] text-[#006064] hover:bg-[#E0F7FA] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    13: {
+      name: '만년설방',
+      className:
+        'bg-[#E0F7FA] text-[#006064] hover:bg-[#E0F7FA] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    23: {
+      name: '만년설방',
+      className:
+        'bg-[#E0F7FA] text-[#006064] hover:bg-[#E0F7FA] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    4: {
+      name: '시험후기',
+      className:
+        'bg-[#FCE7F3] text-[#9D174D] hover:bg-[#FCE7F3] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    14: {
+      name: '시험후기',
+      className:
+        'bg-[#FCE7F3] text-[#9D174D] hover:bg-[#FCE7F3] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+    24: {
+      name: '시험후기',
+      className:
+        'bg-[#FCE7F3] text-[#9D174D] hover:bg-[#FCE7F3] border-none font-semibold px-2.5 py-0.5 rounded-full',
+    },
+  };
+  return (
+    mapping[boardId] || {
+      name: `게시판 ${boardId}`,
+      className:
+        'bg-gray-100 text-gray-700 font-semibold px-2 py-0.5 rounded-full',
+    }
+  );
+};
+
+// 상태별 Row 배경색 매핑 함수
+export const getRowStyle = (status: string) => {
+  if (status.startsWith('신고누적')) {
+    return 'bg-[#FFF9E6] hover:bg-[#FFF2CC] border-b border-gray-100 transition-colors text-yellow-950';
+  }
+  switch (status) {
+    case '삭제됨':
+      return 'bg-[#FFF0F0] hover:bg-[#FFE3E3] border-b border-gray-100 transition-colors text-gray-500 opacity-90';
+    case '관리자삭제':
+      return 'bg-[#FFEBEB] hover:bg-[#FFD6D6] border-b border-gray-100 transition-colors text-red-950';
+    case '관리자비공개':
+      return 'bg-[#F5F7FA] hover:bg-[#E4E8ED] border-b border-gray-100 transition-colors text-slate-900';
+    case '복구':
+      return 'bg-[#EBF7EE] hover:bg-[#D5EEDC] border-b border-gray-100 transition-colors text-green-950';
+    case '비공개해제':
+      return 'bg-[#EBF3FC] hover:bg-[#D5E4F9] border-b border-gray-100 transition-colors text-blue-950';
+    default:
+      return 'bg-white hover:bg-gray-50/50 border-b border-gray-100 text-gray-800';
+  }
+};
+
+// 상태별 배지 스타일 매핑 함수
+export const getStatusBadgeClass = (status: string) => {
+  if (status.startsWith('신고누적')) {
+    return 'bg-[#FFF3E0] text-[#E65100] border-[#FFE0B2] hover:bg-[#FFF3E0] font-semibold text-[11px] px-2 py-0.5 rounded border cursor-pointer';
+  }
+  switch (status) {
+    case '정상':
+      return 'bg-[#EBF7EE] text-[#2A7E3E] border-[#B2E2BD] hover:bg-[#EBF7EE] font-semibold text-[11px] px-2 py-0.5 rounded border cursor-pointer';
+    case '삭제됨':
+      return 'bg-[#FFF0F0] text-[#D32F2F] border-[#FFCDD2] hover:bg-[#FFF0F0] font-semibold text-[11px] px-2 py-0.5 rounded border cursor-pointer';
+    case '관리자삭제':
+      return 'bg-[#FFEBEB] text-[#C62828] border-[#EF9A9A] hover:bg-[#FFEBEB] font-semibold text-[11px] px-2 py-0.5 rounded border cursor-pointer';
+    case '복구':
+      return 'bg-[#EBF7EE] text-[#2A7E3E] border-[#B2E2BD] hover:bg-[#EBF7EE] font-semibold text-[11px] px-2 py-0.5 rounded border cursor-pointer';
+    case '관리자비공개':
+      return 'bg-[#ECEFF1] text-[#37474F] border-[#CFD8DC] hover:bg-[#ECEFF1] font-semibold text-[11px] px-2 py-0.5 rounded border cursor-pointer';
+    case '비공개해제':
+      return 'bg-[#E3F2FD] text-[#0D47A1] border-[#BBDEFB] hover:bg-[#E3F2FD] font-semibold text-[11px] px-2 py-0.5 rounded border cursor-pointer';
+    default:
+      return 'bg-gray-50 text-gray-600 border-gray-200 hover:bg-gray-50 font-semibold text-[11px] px-2 py-0.5 rounded border cursor-pointer';
+  }
+};
+
+// ID 포맷터
+export const formatCommentId = (id: number) =>
+  `C${String(id).padStart(3, '0')}`;
+export const formatPostId = (id: number) => `P${String(id).padStart(3, '0')}`;
+
+// 게시글 상태 결정 헬퍼 함수
+export const getPostStatus = (post: {
+  isVisible: boolean;
+  deletedAt?: string | null;
+  reportCount: number;
+}): string => {
+  if (post.deletedAt != null) {
+    return '관리자삭제';
+  }
+  if (!post.isVisible) {
+    return '관리자비공개';
+  }
+  if (post.reportCount > 0) {
+    return `신고누적 (${post.reportCount})`;
+  }
+  return '정상';
+};


### PR DESCRIPTION
## 🔎 What is this PR?

Close #233 

- [Figma](https://www.figma.com/make/rnQq5yvwZvNEp6jUcSkYxj/%EA%B2%8C%EC%8B%9C%EA%B8%80-%EB%AA%A9%EB%A1%9D?t=b3hpgyy7oijsmwc0-1)
- [Notion](https://www.notion.so/snorose/1-A3-31b7ef0aa3bf81c18535f4db901e5abf?source=copy_link)

## 🎯 변경 사항

###### 주요 변경점을 설명해주세요.

**게시글 관리 기능 구현:**

* 앱 라우팅 및 내비게이션에 `PostManagePage`를 포함하여, 게시글 관리를 위한 새로운 라우트와 페이지 컴포넌트를 추가했습니다. (`src/App.tsx`)

**API 개선 사항:**

* 단건 및 다중 게시글 삭제, 게시글 공개 여부 일괄 업데이트를 위한 새로운 API 함수를 `src/apis/posts.ts` 파일에 구현했습니다. 또한 게시글 검색의 페이지네이션 로직이 0부터 시작하는 인덱스(zero-based indexing)를 사용하도록 조정했습니다.
* 게시글 상태가 변경(mutation)된 후 데이터를 더 쉽게 새로고침할 수 있도록, 게시글 목록 조회 훅에 `refetch` 메서드를 추가했습니다. (`src/domains/Comments/hooks/usePostList.ts`)

**대량 및 단건 게시글 작업:**

* 캐시 무효화(cache invalidation) 및 에러 처리를 포함하여, 게시글의 단건 및 일괄 삭제를 처리하는 `useDeletePost` 및 `useBulkDeletePost` React 훅을 추가했습니다. (`src/domains/Comments/hooks/useDeletePost.ts`, `src/domains/Comments/hooks/useBulkDeletePost.ts`)
* 선택한 게시글들에 대해 일괄 작업(삭제, 복구, 공개 여부 토글)을 수행할 수 있는 `PostBulkActionBar`를 생성했습니다. (`src/domains/Comments/components/PostBulkActionBar.tsx`)

**게시글 관리를 위한 UI 컴포넌트:**

* 선택 기능, 상태 표시, 액션 컨트롤을 갖추고 대량 및 단건 작업을 지원하는 `PostTable` 및 `PostTableRow` 컴포넌트를 구현하여 게시글을 표시할 수 있도록 했습니다. (`src/domains/Comments/components/PostTable.tsx`, `src/domains/Comments/components/PostTableRow.tsx`)

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->
<img width="1512" height="862" alt="스크린샷 2026-05-23 오후 9 50 38" src="https://github.com/user-attachments/assets/400ac787-3a38-4f06-b15a-4a5932c682d6" />

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
