### PR TITLE
[STYLE] #243 사이드 활성화 메뉴 배경색 변경

### DIFF
--- a/src/shared/components/AppSidebar.tsx
+++ b/src/shared/components/AppSidebar.tsx
@@ -13,13 +13,13 @@ import { snoroseLogo } from '@/assets';
 const sidebarMenuButtonClassName = cn(
   'font-semibold hover:bg-blue-50 hover:!text-current',
   'data-[active=true]:bg-blue-200 data-[active=true]:font-semibold',
-  'data-[active=true]:hover:!bg-blue-200 data-[active=true]:hover:!text-current data-[active=true]:active:!bg-blue-200'
+  'data-[active=true]:hover:!bg-blue-200 data-[active=true]:active:!bg-blue-200'
 );
 
 const sidebarMenuSubButtonClassName = cn(
   'hover:bg-blue-50 hover:!text-current',
   'data-[active=true]:bg-blue-100',
-  'data-[active=true]:hover:!bg-blue-100 data-[active=true]:hover:!text-current data-[active=true]:active:!bg-blue-100'
+  'data-[active=true]:hover:!bg-blue-100 data-[active=true]:active:!bg-blue-100'
 );
 
 export const AppSidebar = ({

--- a/src/shared/components/AppSidebar.tsx
+++ b/src/shared/components/AppSidebar.tsx
@@ -12,14 +12,14 @@ import { snoroseLogo } from '@/assets';
 
 const sidebarMenuButtonClassName = cn(
   'font-semibold hover:bg-blue-50 hover:!text-current',
-  'data-[active=true]:bg-blue-50 data-[active=true]:font-semibold data-[active=true]:text-blue-700',
-  'data-[active=true]:hover:!bg-blue-50 data-[active=true]:hover:!text-blue-700 data-[active=true]:active:!bg-blue-50'
+  'data-[active=true]:bg-blue-200 data-[active=true]:font-semibold',
+  'data-[active=true]:hover:!bg-blue-200 data-[active=true]:hover:!text-current data-[active=true]:active:!bg-blue-200'
 );
 
 const sidebarMenuSubButtonClassName = cn(
   'hover:bg-blue-50 hover:!text-current',
-  'data-[active=true]:bg-blue-100 data-[active=true]:font-semibold data-[active=true]:text-blue-600',
-  'data-[active=true]:hover:!bg-blue-100 data-[active=true]:hover:!text-blue-600 data-[active=true]:active:!bg-blue-100'
+  'data-[active=true]:bg-blue-100',
+  'data-[active=true]:hover:!bg-blue-100 data-[active=true]:hover:!text-current data-[active=true]:active:!bg-blue-100'
 );
 
 export const AppSidebar = ({


### PR DESCRIPTION
## 🔎 What is this PR?

Close #243



## 🎯 변경 사항

###### 주요 변경점을 설명해주세요.

- 사이드 활성화 메뉴 배경색 변경 (상위 메뉴 배경색이 더 진하게)

## 📸 스크린샷 (선택 사항)


| Before | After |
| :----: | :---: |
| <img width="181" height="415" alt="image" src="https://github.com/user-attachments/assets/66f4df09-b2d4-47e3-b66b-b63c0da2bb13" /> | <img width="182" height="419" alt="image" src="https://github.com/user-attachments/assets/619df479-d059-4935-a6c4-8caf6c7400a7" />|


## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
