### PR TITLE
[FEAT] #265 시험후기 목록에 필터 추가 및 테이블에 컬럼 추가

### DIFF
--- a/src/apis/reviews.ts
+++ b/src/apis/reviews.ts
@@ -17,7 +17,6 @@ import type {
 // 시험후기 목록 조회 api
 export const getExamReviews = async (params: {
   page: number;
-  keyword?: string;
   startDate?: string;
   endDate?: string;
   keywordAuthor?: string;
@@ -27,6 +26,9 @@ export const getExamReviews = async (params: {
   semester?: string;
   examType?: string;
   isConfirmed?: boolean;
+  isDiscussed?: boolean;
+  isReported?: boolean;
+  statuses?: string;
 }): Promise<ExamReviewsResponse> => {
   const response = await axiosInstance.get(`/v1/admin/reviews`, {
     params,

--- a/src/apis/reviews.ts
+++ b/src/apis/reviews.ts
@@ -9,27 +9,16 @@ import type {
   ConfirmExamReviewResponse,
   DeleteExamReviewResponse,
   ExamReviewDetailResponse,
+  ExamReviewSearchParams,
   ExamReviewsResponse,
   UpdateExamReviewRequest,
   UpdateExamReviewResponse,
 } from '@/domains/Reviews/types';
 
 // 시험후기 목록 조회 api
-export const getExamReviews = async (params: {
-  page: number;
-  startDate?: string;
-  endDate?: string;
-  keywordAuthor?: string;
-  keywordPost?: string;
-  sort?: string;
-  lectureYear?: number;
-  semester?: string;
-  examType?: string;
-  isConfirmed?: boolean;
-  isDiscussed?: boolean;
-  isReported?: boolean;
-  statuses?: string;
-}): Promise<ExamReviewsResponse> => {
+export const getExamReviews = async (
+  params: ExamReviewSearchParams & { page: number }
+): Promise<ExamReviewsResponse> => {
   const response = await axiosInstance.get(`/v1/admin/reviews`, {
     params,
   });

--- a/src/domains/Reviews/components/ExamMultiSelect.tsx
+++ b/src/domains/Reviews/components/ExamMultiSelect.tsx
@@ -66,12 +66,12 @@ export const ExamMultiSelect = ({
           side={side}
           align={align}
           sideOffset={4}
-          className={`text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-[200px] min-w-[8rem] origin-[var(--radix-select-content-transform-origin)] overflow-x-hidden overflow-y-auto rounded-md border bg-blue-50 shadow-md ${contentClassName}`}
+          className={`bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-[200px] min-w-[8rem] origin-[var(--radix-select-content-transform-origin)] overflow-x-hidden overflow-y-auto rounded-md border shadow-md ${contentClassName}`}
         >
           <div className='p-1'>
             {/* 전체 선택/해제 체크박스 */}
             <div
-              className='relative mb-1 flex w-full cursor-default items-center rounded-sm border-b border-gray-200 px-1.5 py-1.5 text-xs outline-none select-none hover:bg-blue-100/50'
+              className='focus:bg-accent focus:text-accent-foreground hover:bg-accent hover:text-accent-foreground relative mb-1 flex w-full cursor-default items-center rounded-sm border-b px-2 py-1.5 text-sm outline-none select-none'
               onClick={handleSelectAll}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
@@ -93,7 +93,7 @@ export const ExamMultiSelect = ({
                 }`}
                 tabIndex={-1}
               />
-              <span className='flex-1 font-medium'>전체 선택</span>
+              <span className='flex-1 text-left font-normal'>전체 선택</span>
             </div>
             {options.map((option) => {
               const isSelected = value.includes(option);
@@ -103,7 +103,7 @@ export const ExamMultiSelect = ({
               return (
                 <div
                   key={option}
-                  className='relative flex w-full cursor-default items-center rounded-sm px-1.5 py-1.5 text-xs outline-none select-none hover:bg-blue-100/50'
+                  className='focus:bg-accent focus:text-accent-foreground hover:bg-accent hover:text-accent-foreground relative flex w-full cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none'
                   onClick={() => handleToggle(option)}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
@@ -126,7 +126,7 @@ export const ExamMultiSelect = ({
                     }`}
                     tabIndex={-1}
                   />
-                  <span className='flex-1'>{option}</span>
+                  <span className='flex-1 text-left'>{option}</span>
                   {showStatusDot && statusOption && (
                     <div className='ml-2 h-2 w-2 shrink-0 rounded-full bg-blue-500' />
                   )}

--- a/src/domains/Reviews/components/ExamSearch.tsx
+++ b/src/domains/Reviews/components/ExamSearch.tsx
@@ -1,12 +1,15 @@
 import { useState } from 'react';
 
-import { X } from 'lucide-react';
+import { ChevronDown, X } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Button, Input, Select } from '@/shared/components/ui';
-import { EXAM_TYPE_LIST, SEMESTER_LIST } from '@/shared/constants';
+import {
+  EXAM_REVIEW_PROCESS_STATUS,
+  EXAM_TYPE_LIST,
+  SEMESTER_LIST,
+} from '@/shared/constants';
 
-import { ExamConfirmStatusBadge } from '@/domains/Reviews/components';
 import {
   type ExamReviewSearchParams,
   isExamReviewSort,
@@ -16,6 +19,9 @@ import {
   convertSemesterToEnum,
   extractYearFromSemester,
 } from '@/domains/Reviews/utils';
+
+import { ExamConfirmStatusBadge } from './ExamConfirmStatusBadge';
+import { ExamMultiSelect } from './ExamMultiSelect';
 
 interface ExamSearchProps {
   onSearchChange: (params: ExamReviewSearchParams) => void;
@@ -27,7 +33,59 @@ interface ExamSearchProps {
   initialSemester?: string;
   initialExamType?: string;
   initialIsConfirmed?: boolean;
+  initialIsDiscussed?: boolean;
+  initialIsReported?: boolean;
+  initialStatuses?: string;
 }
+
+const ALL_SELECTED = '전체';
+const TRUE_SELECTED = 'TRUE';
+const FALSE_SELECTED = 'FALSE';
+const CONFIRMED_SELECTED = 'CONFIRMED';
+const UNCONFIRMED_SELECTED = 'UNCONFIRMED';
+const PROCESS_STATUS_OPTIONS: string[] = EXAM_REVIEW_PROCESS_STATUS.map(
+  (status) => status.label
+);
+
+const isDefined = <T,>(value: T | undefined): value is T => value !== undefined;
+
+const getBooleanFilterValue = (value?: boolean): string => {
+  if (value === true) {
+    return TRUE_SELECTED;
+  }
+
+  if (value === false) {
+    return FALSE_SELECTED;
+  }
+
+  return ALL_SELECTED;
+};
+
+const getStatusLabelsFromCodes = (statuses?: string): string[] => {
+  if (!statuses) {
+    return [];
+  }
+
+  return statuses
+    .split(',')
+    .map((status) => status.trim())
+    .map((statusCode) => {
+      return EXAM_REVIEW_PROCESS_STATUS.find(
+        (status) => status.code === statusCode
+      )?.label;
+    })
+    .filter(isDefined);
+};
+
+const getStatusCodesFromLabels = (statusLabels: string[]): string =>
+  statusLabels
+    .map((statusLabel) => {
+      return EXAM_REVIEW_PROCESS_STATUS.find(
+        (status) => status.label === statusLabel
+      )?.code;
+    })
+    .filter(isDefined)
+    .join(',');
 
 export default function ExamSearch({
   onSearchChange,
@@ -39,13 +97,12 @@ export default function ExamSearch({
   initialSemester,
   initialExamType,
   initialIsConfirmed,
+  initialIsDiscussed,
+  initialIsReported,
+  initialStatuses,
 }: ExamSearchProps) {
-  const ALL_SELECTED = '전체';
-  const CONFIRMED_SELECTED = 'CONFIRMED';
-  const UNCONFIRMED_SELECTED = 'UNCONFIRMED';
-
   // key prop을 사용하여 prop 변경 시 컴포넌트 재초기화 (useEffect 대신)
-  const searchKey = `${initialStartDate}-${initialEndDate}-${initialKeywordAuthor}-${initialKeywordPost}-${initialSort}-${initialSemester}-${initialExamType}-${initialIsConfirmed}`;
+  const searchKey = `${initialStartDate}-${initialEndDate}-${initialKeywordAuthor}-${initialKeywordPost}-${initialSort}-${initialSemester}-${initialExamType}-${initialIsConfirmed}-${initialIsDiscussed}-${initialIsReported}-${initialStatuses}`;
 
   // 내부 상태는 사용자 입력용으로만 사용
   const [startDate, setStartDate] = useState<string>(initialStartDate);
@@ -69,6 +126,15 @@ export default function ExamSearch({
         ? UNCONFIRMED_SELECTED
         : ALL_SELECTED
   );
+  const [discussionStatus, setDiscussionStatus] = useState<string>(
+    getBooleanFilterValue(initialIsDiscussed)
+  );
+  const [reportStatus, setReportStatus] = useState<string>(
+    getBooleanFilterValue(initialIsReported)
+  );
+  const [selectedStatuses, setSelectedStatuses] = useState<string[]>(
+    getStatusLabelsFromCodes(initialStatuses)
+  );
 
   // 검색 실행 함수 (현재 상태 기반)
   const handleSearch = () => {
@@ -87,6 +153,9 @@ export default function ExamSearch({
         semester,
         examType,
         confirmStatus,
+        discussionStatus,
+        reportStatus,
+        selectedStatuses,
       })
     );
   };
@@ -100,6 +169,9 @@ export default function ExamSearch({
     semester: targetSemester,
     examType: targetExamType,
     confirmStatus: targetConfirmStatus,
+    discussionStatus: targetDiscussionStatus,
+    reportStatus: targetReportStatus,
+    selectedStatuses: targetSelectedStatuses,
   }: {
     startDate: string;
     endDate: string;
@@ -109,6 +181,9 @@ export default function ExamSearch({
     semester: string;
     examType: string;
     confirmStatus: string;
+    discussionStatus: string;
+    reportStatus: string;
+    selectedStatuses: string[];
   }) => {
     const params: ExamReviewSearchParams = {};
 
@@ -152,6 +227,27 @@ export default function ExamSearch({
       params.isConfirmed = false;
     }
 
+    if (targetDiscussionStatus === TRUE_SELECTED) {
+      params.isDiscussed = true;
+    }
+
+    if (targetDiscussionStatus === FALSE_SELECTED) {
+      params.isDiscussed = false;
+    }
+
+    if (targetReportStatus === TRUE_SELECTED) {
+      params.isReported = true;
+    }
+
+    if (targetReportStatus === FALSE_SELECTED) {
+      params.isReported = false;
+    }
+
+    const statuses = getStatusCodesFromLabels(targetSelectedStatuses);
+    if (statuses) {
+      params.statuses = statuses;
+    }
+
     return params;
   };
 
@@ -165,6 +261,9 @@ export default function ExamSearch({
       semester: string;
       examType: string;
       confirmStatus: string;
+      discussionStatus: string;
+      reportStatus: string;
+      selectedStatuses: string[];
     }>
   ) => {
     onSearchChange(
@@ -177,6 +276,9 @@ export default function ExamSearch({
         semester,
         examType,
         confirmStatus,
+        discussionStatus,
+        reportStatus,
+        selectedStatuses,
         ...nextParams,
       })
     );
@@ -210,6 +312,9 @@ export default function ExamSearch({
     setSemester(ALL_SELECTED);
     setExamType(ALL_SELECTED);
     setConfirmStatus(ALL_SELECTED);
+    setDiscussionStatus(ALL_SELECTED);
+    setReportStatus(ALL_SELECTED);
+    setSelectedStatuses([]);
     onSearchChange({});
   };
 
@@ -387,6 +492,75 @@ export default function ExamSearch({
             </Select.Item>
           </Select.Content>
         </Select>
+
+        <Select
+          value={discussionStatus}
+          onValueChange={(value) => {
+            setDiscussionStatus(value);
+            handleSearchWithParams({ discussionStatus: value });
+          }}
+        >
+          <Select.Trigger className='h-9 w-[150px] text-sm'>
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Content align='start'>
+            <Select.Item value={ALL_SELECTED} className='text-sm'>
+              논의 여부 전체
+            </Select.Item>
+            <Select.Item value={TRUE_SELECTED} className='text-sm'>
+              논의 있음
+            </Select.Item>
+            <Select.Item value={FALSE_SELECTED} className='text-sm'>
+              논의 없음
+            </Select.Item>
+          </Select.Content>
+        </Select>
+
+        <Select
+          value={reportStatus}
+          onValueChange={(value) => {
+            setReportStatus(value);
+            handleSearchWithParams({ reportStatus: value });
+          }}
+        >
+          <Select.Trigger className='h-9 w-[150px] text-sm'>
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Content align='start'>
+            <Select.Item value={ALL_SELECTED} className='text-sm'>
+              신고 여부 전체
+            </Select.Item>
+            <Select.Item value={TRUE_SELECTED} className='text-sm'>
+              신고 있음
+            </Select.Item>
+            <Select.Item value={FALSE_SELECTED} className='text-sm'>
+              신고 없음
+            </Select.Item>
+          </Select.Content>
+        </Select>
+
+        <ExamMultiSelect
+          value={selectedStatuses}
+          onValueChange={(value) => {
+            setSelectedStatuses(value);
+            handleSearchWithParams({ selectedStatuses: value });
+          }}
+          options={PROCESS_STATUS_OPTIONS}
+          contentClassName='w-[190px]'
+        >
+          <Button
+            type='button'
+            variant='outline'
+            className='border-input h-9 w-[190px] justify-between bg-transparent px-3 text-sm font-normal hover:bg-transparent'
+          >
+            <span className='truncate'>
+              {selectedStatuses.length > 0
+                ? `처리 상태 ${selectedStatuses.length}개`
+                : '처리 상태 전체'}
+            </span>
+            <ChevronDown className='size-4 opacity-50' />
+          </Button>
+        </ExamMultiSelect>
       </div>
     </div>
   );

--- a/src/domains/Reviews/components/ExamSearch.tsx
+++ b/src/domains/Reviews/components/ExamSearch.tsx
@@ -406,9 +406,6 @@ export default function ExamSearch({
             <Select.Item value='DESC' className='text-sm'>
               제목 내림차순
             </Select.Item>
-            <Select.Item value='REPORT' className='text-sm'>
-              신고순
-            </Select.Item>
           </Select.Content>
         </Select>
 

--- a/src/domains/Reviews/components/ExamTable.tsx
+++ b/src/domains/Reviews/components/ExamTable.tsx
@@ -7,7 +7,8 @@ import {
   useState,
 } from 'react';
 
-import { Table } from '@/shared/components/ui';
+import { Badge, Table } from '@/shared/components/ui';
+import { EXAM_REVIEW_PROCESS_STATUS } from '@/shared/constants';
 import { cn } from '@/shared/lib';
 
 import {
@@ -20,6 +21,7 @@ import {
 import { useExamReviews } from '@/domains/Reviews/hooks';
 import type {
   ExamReview,
+  ExamReviewProcessStatus,
   ExamReviewSearchParams,
 } from '@/domains/Reviews/types';
 
@@ -33,6 +35,83 @@ interface ExamReviewTableColumn {
   render?: (review: ExamReview) => ReactNode;
 }
 
+const PROCESS_STATUS_BADGE_CLASS_NAMES: Record<
+  ExamReviewProcessStatus,
+  string
+> = {
+  VISIBLE: 'bg-gray-100 text-gray-700 dark:bg-gray-900 dark:text-gray-300',
+  USER_DELETED:
+    'bg-slate-100 text-slate-700 dark:bg-slate-900 dark:text-slate-300',
+  ADMIN_DELETED: 'bg-red-50 text-red-700 dark:bg-red-950 dark:text-red-300',
+  ADMIN_HIDDEN:
+    'bg-orange-50 text-orange-700 dark:bg-orange-950 dark:text-orange-300',
+  AUTO_HIDDEN:
+    'bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-300',
+  SANCTIONED: 'bg-rose-50 text-rose-700 dark:bg-rose-950 dark:text-rose-300',
+  DESANCTIONED:
+    'bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300',
+};
+
+const getProcessStatusLabel = (status: ExamReviewProcessStatus): string =>
+  EXAM_REVIEW_PROCESS_STATUS.find((option) => option.code === status)?.label ??
+  status;
+
+const renderBooleanBadge = (
+  value: boolean,
+  trueLabel: string,
+  falseLabel: string
+) => (
+  <Badge
+    variant='outline'
+    className={cn(
+      'max-w-full truncate',
+      value
+        ? 'border-blue-200 bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300'
+        : 'text-gray-500 dark:text-gray-400'
+    )}
+    title={value ? trueLabel : falseLabel}
+  >
+    {value ? trueLabel : falseLabel}
+  </Badge>
+);
+
+const renderReportBadge = (review: ExamReview) => {
+  const label = review.isReported ? `신고 ${review.reportCount}` : '신고 없음';
+
+  return (
+    <Badge
+      variant='outline'
+      className={cn(
+        'max-w-full truncate',
+        review.isReported
+          ? 'border-red-200 bg-red-50 text-red-700 dark:bg-red-950 dark:text-red-300'
+          : 'text-gray-500 dark:text-gray-400'
+      )}
+      title={label}
+    >
+      {label}
+    </Badge>
+  );
+};
+
+const renderProcessStatusBadge = (review: ExamReview) => {
+  const label = review.processStatuses.map(getProcessStatusLabel).join(', ');
+
+  return (
+    <div className='flex flex-wrap gap-1' title={label}>
+      {review.processStatuses.map((status) => (
+        <Badge
+          key={status}
+          variant='outline'
+          className={PROCESS_STATUS_BADGE_CLASS_NAMES[status]}
+        >
+          {getProcessStatusLabel(status)}
+        </Badge>
+      ))}
+    </div>
+  );
+};
+
 const EXAM_REVIEW_TABLE_COLUMNS: ExamReviewTableColumn[] = [
   {
     key: 'status',
@@ -43,8 +122,27 @@ const EXAM_REVIEW_TABLE_COLUMNS: ExamReviewTableColumn[] = [
     ),
   },
   { key: 'id', label: 'postId', width: '90px' },
-  { key: 'reviewTitle', label: '시험후기명' },
+  { key: 'reviewTitle', label: '시험후기명', width: '320px' },
   { key: 'userDisplay', label: '작성자', width: '120px' },
+  {
+    key: 'isDiscussed',
+    label: '논의 여부',
+    width: '92px',
+    render: (review: ExamReview) =>
+      renderBooleanBadge(review.isDiscussed, '논의 있음', '논의 없음'),
+  },
+  {
+    key: 'isReported',
+    label: '신고 여부',
+    width: '92px',
+    render: renderReportBadge,
+  },
+  {
+    key: 'processStatuses',
+    label: '처리상태',
+    width: '92px',
+    render: renderProcessStatusBadge,
+  },
   { key: 'uploadTime', label: '작성일', width: '150px' },
 ];
 
@@ -107,6 +205,7 @@ export default function ExamTable({
   );
   const hasNext = queryData?.hasNext ?? false;
   const totalPage = queryData?.totalPage;
+  const columnCount = EXAM_REVIEW_TABLE_COLUMNS.length;
 
   // 선택된 행이 있으면 업데이트된 데이터로 자동 선택
   useEffect(() => {
@@ -129,7 +228,7 @@ export default function ExamTable({
 
   return (
     <>
-      <div className='w-full overflow-hidden rounded-md border'>
+      <div className='w-full overflow-x-auto rounded-md border'>
         <Table className='w-full table-fixed rounded-lg bg-white shadow'>
           <colgroup>
             {EXAM_REVIEW_TABLE_COLUMNS.map((column) => (
@@ -152,9 +251,12 @@ export default function ExamTable({
 
           <Table.Body>
             {isLoading ? (
-              <ExamTableSkeleton itemsPerPage={ITEMS_PER_PAGE} />
+              <ExamTableSkeleton
+                itemsPerPage={ITEMS_PER_PAGE}
+                columnCount={columnCount}
+              />
             ) : currentPageData.length === 0 ? (
-              <ExamTableEmpty />
+              <ExamTableEmpty columnCount={columnCount} />
             ) : (
               <>
                 {currentPageData.map((review: ExamReview) => {
@@ -178,7 +280,11 @@ export default function ExamTable({
                       {EXAM_REVIEW_TABLE_COLUMNS.map((column) => (
                         <Table.Cell
                           key={column.key}
-                          className='overflow-hidden text-ellipsis whitespace-nowrap'
+                          className={cn(
+                            'overflow-hidden text-ellipsis whitespace-nowrap',
+                            column.key === 'processStatuses' &&
+                              'whitespace-normal'
+                          )}
                         >
                           {column.render
                             ? column.render(review)
@@ -192,6 +298,7 @@ export default function ExamTable({
                 })}
                 <ExamTableEmptyRows
                   count={ITEMS_PER_PAGE - currentPageData.length}
+                  columnCount={columnCount}
                 />
               </>
             )}

--- a/src/domains/Reviews/components/ExamTable.tsx
+++ b/src/domains/Reviews/components/ExamTable.tsx
@@ -94,6 +94,9 @@ export default function ExamTable({
     semester: searchParams.semester,
     examType: searchParams.examType,
     isConfirmed: searchParams.isConfirmed,
+    isDiscussed: searchParams.isDiscussed,
+    isReported: searchParams.isReported,
+    statuses: searchParams.statuses,
     enabled: !propData,
     refreshKey, // refreshKey를 queryKey에 포함시켜 자동 refetch
   });

--- a/src/domains/Reviews/components/ExamTableFallback.tsx
+++ b/src/domains/Reviews/components/ExamTableFallback.tsx
@@ -1,5 +1,7 @@
 import { Skeleton, Table } from '@/shared/components/ui';
 
+const DEFAULT_EXAM_TABLE_COLUMN_COUNT = 8;
+
 // ======= types =======
 interface ExamTableSkeletonProps {
   itemsPerPage?: number;
@@ -18,7 +20,7 @@ interface ExamTableEmptyProps {
 // ======= components =======
 export function ExamTableSkeleton({
   itemsPerPage = 10,
-  columnCount = 5,
+  columnCount = DEFAULT_EXAM_TABLE_COLUMN_COUNT,
 }: ExamTableSkeletonProps) {
   return (
     <>
@@ -35,7 +37,9 @@ export function ExamTableSkeleton({
   );
 }
 
-export function ExamTableEmpty({ columnCount = 5 }: ExamTableEmptyProps) {
+export function ExamTableEmpty({
+  columnCount = DEFAULT_EXAM_TABLE_COLUMN_COUNT,
+}: ExamTableEmptyProps) {
   return (
     <Table.Row>
       <Table.Cell colSpan={columnCount} className='h-[240px] p-0 text-gray-500'>
@@ -49,7 +53,7 @@ export function ExamTableEmpty({ columnCount = 5 }: ExamTableEmptyProps) {
 
 export function ExamTableEmptyRows({
   count,
-  columnCount = 5,
+  columnCount = DEFAULT_EXAM_TABLE_COLUMN_COUNT,
 }: ExamTableEmptyRowsProps) {
   if (count <= 0) return null;
 

--- a/src/domains/Reviews/components/ExamTableFallback.tsx
+++ b/src/domains/Reviews/components/ExamTableFallback.tsx
@@ -3,45 +3,42 @@ import { Skeleton, Table } from '@/shared/components/ui';
 // ======= types =======
 interface ExamTableSkeletonProps {
   itemsPerPage?: number;
+  columnCount?: number;
 }
 
 interface ExamTableEmptyRowsProps {
   count: number;
+  columnCount?: number;
+}
+
+interface ExamTableEmptyProps {
+  columnCount?: number;
 }
 
 // ======= components =======
 export function ExamTableSkeleton({
   itemsPerPage = 10,
+  columnCount = 5,
 }: ExamTableSkeletonProps) {
   return (
     <>
       {Array.from({ length: itemsPerPage }).map((_, index) => (
         <Table.Row key={`skeleton-${index}`} className='[&_td]:h-[40px]'>
-          <Table.Cell>
-            <Skeleton className='h-4 w-full' />
-          </Table.Cell>
-          <Table.Cell>
-            <Skeleton className='h-4 w-full' />
-          </Table.Cell>
-          <Table.Cell>
-            <Skeleton className='h-4 w-full' />
-          </Table.Cell>
-          <Table.Cell>
-            <Skeleton className='h-4 w-full' />
-          </Table.Cell>
-          <Table.Cell>
-            <Skeleton className='h-4 w-full' />
-          </Table.Cell>
+          {Array.from({ length: columnCount }).map((_, cellIndex) => (
+            <Table.Cell key={`skeleton-${index}-${cellIndex}`}>
+              <Skeleton className='h-4 w-full' />
+            </Table.Cell>
+          ))}
         </Table.Row>
       ))}
     </>
   );
 }
 
-export function ExamTableEmpty() {
+export function ExamTableEmpty({ columnCount = 5 }: ExamTableEmptyProps) {
   return (
     <Table.Row>
-      <Table.Cell colSpan={5} className='h-[240px] p-0 text-gray-500'>
+      <Table.Cell colSpan={columnCount} className='h-[240px] p-0 text-gray-500'>
         <div className='flex h-full items-center justify-center'>
           해당하는 데이터가 없습니다
         </div>
@@ -50,18 +47,19 @@ export function ExamTableEmpty() {
   );
 }
 
-export function ExamTableEmptyRows({ count }: ExamTableEmptyRowsProps) {
+export function ExamTableEmptyRows({
+  count,
+  columnCount = 5,
+}: ExamTableEmptyRowsProps) {
   if (count <= 0) return null;
 
   return (
     <>
       {Array.from({ length: count }).map((_, index) => (
         <Table.Row key={`empty-${index}`} className='[&_td]:h-[24px]'>
-          <Table.Cell>&nbsp;</Table.Cell>
-          <Table.Cell>&nbsp;</Table.Cell>
-          <Table.Cell>&nbsp;</Table.Cell>
-          <Table.Cell>&nbsp;</Table.Cell>
-          <Table.Cell>&nbsp;</Table.Cell>
+          {Array.from({ length: columnCount }).map((_, cellIndex) => (
+            <Table.Cell key={`empty-${index}-${cellIndex}`}>&nbsp;</Table.Cell>
+          ))}
         </Table.Row>
       ))}
     </>

--- a/src/domains/Reviews/hooks/use-exam-reviews.ts
+++ b/src/domains/Reviews/hooks/use-exam-reviews.ts
@@ -72,6 +72,9 @@ export const useExamReviews = (params: UseExamReviewsParams) => {
     semester,
     examType,
     isConfirmed,
+    isDiscussed,
+    isReported,
+    statuses,
     enabled = true,
     refreshKey,
   } = params;
@@ -89,6 +92,9 @@ export const useExamReviews = (params: UseExamReviewsParams) => {
       semester,
       examType,
       isConfirmed,
+      isDiscussed,
+      isReported,
+      statuses,
       refreshKey,
     ],
     queryFn: async () => {
@@ -103,6 +109,9 @@ export const useExamReviews = (params: UseExamReviewsParams) => {
         semester,
         examType,
         isConfirmed,
+        isDiscussed,
+        isReported,
+        statuses,
       });
 
       if (!response.isSuccess || !response.result) {

--- a/src/domains/Reviews/hooks/use-exam-reviews.ts
+++ b/src/domains/Reviews/hooks/use-exam-reviews.ts
@@ -5,6 +5,7 @@ import { formatDateTimeToMinutes } from '@/shared/utils';
 import { STATUS } from '@/domains/Reviews/constants';
 import type {
   ExamReview,
+  ExamReviewProcessStatus,
   ExamReviewSearchParams,
   ExamReviews,
 } from '@/domains/Reviews/types';
@@ -20,6 +21,29 @@ interface UseExamReviewsParams extends ExamReviewSearchParams {
   enabled?: boolean;
   refreshKey?: number;
 }
+
+const isSanctioned = (value: ExamReviews['isSanctioned']): boolean =>
+  value === true || value === 'true';
+
+const getProcessStatuses = (
+  apiData: ExamReviews
+): ExamReviewProcessStatus[] => {
+  const processStatuses: ExamReviewProcessStatus[] = [];
+
+  if (apiData.deletionStatus && apiData.deletionStatus !== 'VISIBLE') {
+    processStatuses.push(apiData.deletionStatus);
+  }
+
+  if (apiData.visibilityStatus && apiData.visibilityStatus !== 'VISIBLE') {
+    processStatuses.push(apiData.visibilityStatus);
+  }
+
+  if (isSanctioned(apiData.isSanctioned)) {
+    processStatuses.push('SANCTIONED');
+  }
+
+  return processStatuses.length > 0 ? processStatuses : ['VISIBLE'];
+};
 
 const transformApiResponseToExamReview = (apiData: ExamReviews): ExamReview => {
   const reviewTitle = apiData.title || apiData.content || '';
@@ -44,6 +68,7 @@ const transformApiResponseToExamReview = (apiData: ExamReviews): ExamReview => {
         ? STATUS.UNCONFIRMED
         : apiData.status || STATUS.UNCONFIRMED;
   const userDisplay = apiData.userName || apiData.userDisplay || '';
+  const reportCount = apiData.reportCount ?? 0;
 
   return {
     id: apiData.postId,
@@ -57,6 +82,10 @@ const transformApiResponseToExamReview = (apiData: ExamReviews): ExamReview => {
     questionDetail: '',
     uploadTime,
     userDisplay,
+    isDiscussed: apiData.isDiscussed ?? false,
+    isReported: reportCount > 0,
+    reportCount,
+    processStatuses: getProcessStatuses(apiData),
   };
 };
 

--- a/src/domains/Reviews/types/exam.ts
+++ b/src/domains/Reviews/types/exam.ts
@@ -14,7 +14,7 @@ export type ExamType = (typeof EXAM_TYPE)[keyof typeof EXAM_TYPE];
 
 export type Status = (typeof STATUS)[keyof typeof STATUS];
 
-export const EXAM_REVIEW_SORTS = ['ASC', 'DESC', 'REPORT'] as const;
+export const EXAM_REVIEW_SORTS = ['ASC', 'DESC'] as const;
 
 export type ExamReviewSort = (typeof EXAM_REVIEW_SORTS)[number];
 

--- a/src/domains/Reviews/types/exam.ts
+++ b/src/domains/Reviews/types/exam.ts
@@ -33,6 +33,9 @@ export interface ExamReviewSearchParams {
   semester?: string;
   examType?: string;
   isConfirmed?: boolean;
+  isDiscussed?: boolean;
+  isReported?: boolean;
+  statuses?: string;
 }
 
 export interface ExamReview {

--- a/src/domains/Reviews/types/exam.ts
+++ b/src/domains/Reviews/types/exam.ts
@@ -18,6 +18,15 @@ export const EXAM_REVIEW_SORTS = ['ASC', 'DESC'] as const;
 
 export type ExamReviewSort = (typeof EXAM_REVIEW_SORTS)[number];
 
+export type ExamReviewProcessStatus =
+  | 'VISIBLE'
+  | 'USER_DELETED'
+  | 'ADMIN_DELETED'
+  | 'ADMIN_HIDDEN'
+  | 'AUTO_HIDDEN'
+  | 'SANCTIONED'
+  | 'DESANCTIONED';
+
 export const isExamReviewSort = (
   value?: string | null
 ): value is ExamReviewSort =>
@@ -50,6 +59,10 @@ export interface ExamReview {
   questionDetail: string;
   uploadTime: string;
   userDisplay: string;
+  isDiscussed: boolean;
+  isReported: boolean;
+  reportCount: number;
+  processStatuses: ExamReviewProcessStatus[];
 }
 
 export interface ExamReviews {
@@ -63,6 +76,11 @@ export interface ExamReviews {
   encryptedUserId: string | null;
   userDisplay?: string | null;
   userName: string | null;
+  reportCount?: number;
+  isDiscussed?: boolean;
+  deletionStatus?: ExamReviewProcessStatus | null;
+  isSanctioned?: boolean | 'true' | 'false' | null;
+  visibilityStatus?: ExamReviewProcessStatus | null;
   lectureYear?: number;
   lectureSemester?: Semester;
   examType?: ExamType;

--- a/src/domains/Reviews/types/index.ts
+++ b/src/domains/Reviews/types/index.ts
@@ -5,6 +5,7 @@ export type {
   ExamReview,
   ExamReviewDetailResponse,
   ExamReviewDetailResult,
+  ExamReviewProcessStatus,
   ExamReviews,
   ExamReviewSearchParams,
   ExamReviewSort,

--- a/src/pages/reviews/ExamReviewPage.tsx
+++ b/src/pages/reviews/ExamReviewPage.tsx
@@ -286,6 +286,10 @@ export default function ExamReviewPage() {
                 questionDetail: updatedDetail.questionDetail,
                 uploadTime,
                 userDisplay: updatedDetail.userDisplay,
+                isDiscussed: selectedExamReview.isDiscussed,
+                isReported: selectedExamReview.isReported,
+                reportCount: selectedExamReview.reportCount,
+                processStatuses: selectedExamReview.processStatuses,
               };
 
               updatedData[itemIndex] = updatedItem;

--- a/src/pages/reviews/ExamReviewPage.tsx
+++ b/src/pages/reviews/ExamReviewPage.tsx
@@ -110,6 +110,27 @@ export default function ExamReviewPage() {
       params.isConfirmed = false;
     }
 
+    const isDiscussed = searchParamsFromUrl.get('isDiscussed');
+    if (isDiscussed === 'true') {
+      params.isDiscussed = true;
+    }
+    if (isDiscussed === 'false') {
+      params.isDiscussed = false;
+    }
+
+    const isReported = searchParamsFromUrl.get('isReported');
+    if (isReported === 'true') {
+      params.isReported = true;
+    }
+    if (isReported === 'false') {
+      params.isReported = false;
+    }
+
+    const statuses = searchParamsFromUrl.get('statuses');
+    if (statuses) {
+      params.statuses = statuses;
+    }
+
     // 실제로 검색 파라미터가 변경되었는지 확인
     const hasChanged =
       params.startDate !== searchParams.startDate ||
@@ -120,7 +141,10 @@ export default function ExamReviewPage() {
       params.lectureYear !== searchParams.lectureYear ||
       params.semester !== searchParams.semester ||
       params.examType !== searchParams.examType ||
-      params.isConfirmed !== searchParams.isConfirmed;
+      params.isConfirmed !== searchParams.isConfirmed ||
+      params.isDiscussed !== searchParams.isDiscussed ||
+      params.isReported !== searchParams.isReported ||
+      params.statuses !== searchParams.statuses;
 
     if (hasChanged) {
       setSearchParams(params);
@@ -157,6 +181,15 @@ export default function ExamReviewPage() {
     }
     if (params.isConfirmed !== undefined) {
       newSearchParams.set('isConfirmed', String(params.isConfirmed));
+    }
+    if (params.isDiscussed !== undefined) {
+      newSearchParams.set('isDiscussed', String(params.isDiscussed));
+    }
+    if (params.isReported !== undefined) {
+      newSearchParams.set('isReported', String(params.isReported));
+    }
+    if (params.statuses) {
+      newSearchParams.set('statuses', params.statuses);
     }
     // 검색 시 첫 페이지로 이동
     newSearchParams.set('page', '1');
@@ -202,6 +235,9 @@ export default function ExamReviewPage() {
             searchParams.semester,
             searchParams.examType,
             searchParams.isConfirmed,
+            searchParams.isDiscussed,
+            searchParams.isReported,
+            searchParams.statuses,
             refreshKey,
           ];
 
@@ -391,6 +427,21 @@ export default function ExamReviewPage() {
                   ? false
                   : undefined
             }
+            initialIsDiscussed={
+              searchParamsFromUrl.get('isDiscussed') === 'true'
+                ? true
+                : searchParamsFromUrl.get('isDiscussed') === 'false'
+                  ? false
+                  : undefined
+            }
+            initialIsReported={
+              searchParamsFromUrl.get('isReported') === 'true'
+                ? true
+                : searchParamsFromUrl.get('isReported') === 'false'
+                  ? false
+                  : undefined
+            }
+            initialStatuses={searchParamsFromUrl.get('statuses') || ''}
             initialStartDate={searchParamsFromUrl.get('startDate') || ''}
           />
         </div>

--- a/src/shared/constants/exam-table-options.ts
+++ b/src/shared/constants/exam-table-options.ts
@@ -7,6 +7,17 @@ export const EXAM_CONFIRM_STATUS = [
   { code: 'DELETED', label: '삭제됨' },
 ] as const;
 
+// 시험후기 게시글 처리 상태 리스트
+export const EXAM_REVIEW_PROCESS_STATUS = [
+  { code: 'VISIBLE', label: '노출' },
+  { code: 'USER_DELETED', label: '유저 삭제' },
+  { code: 'ADMIN_DELETED', label: '어드민 삭제' },
+  { code: 'ADMIN_HIDDEN', label: '어드민 비공개' },
+  { code: 'AUTO_HIDDEN', label: '비공개 (신고 5개 이상)' },
+  { code: 'SANCTIONED', label: '징계' },
+  { code: 'DESANCTIONED', label: '징계 없음' },
+] as const;
+
 // 수강 학기 자동 생성 함수 (2007년 ~ 현재년도)
 const generateSemesterList = (): string[] => {
   const currentYear = new Date().getFullYear();


### PR DESCRIPTION
## 🔎 What is this PR?

Close #265

## 🎯 변경 사항

###### 주요 변경점을 설명해주세요.

- 시험후기 목록 필터 및 컬럼 추가
  - `논의 여부`
  - `신고 여부`
  - `처리 상태` (복수 옵션 선택 가능) 
- 정렬 순서 변경
  - `신고순` 옵션 제거 

## 📸 스크린샷 (선택 사항)


| Before | After |
| :----: | :---: |
| <img width="2940" height="1670" alt="image" src="https://github.com/user-attachments/assets/fb544d87-ae5c-432f-9161-ca3533dcb12b" /> |  <img width="2940" height="1670" alt="image" src="https://github.com/user-attachments/assets/738367b3-52c3-4ffa-a471-a0917048faaf" />|


## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
