### PR TITLE
feat: 시험후기 상세 조회 기능 개선

### DIFF
--- a/src/apis/reviews.ts
+++ b/src/apis/reviews.ts
@@ -74,7 +74,7 @@ export const deleteExamReview = async (
 export const getExamReviewDetail = async (
   postId: number
 ): Promise<ExamReviewDetailResponse> => {
-  const response = await axiosInstance.get(`/v1/reviews/${postId}`);
+  const response = await axiosInstance.get(`/v1/admin/reviews/${postId}`);
   return response.data;
 };
 

--- a/src/domains/Reviews/components/ExamDetailSection.tsx
+++ b/src/domains/Reviews/components/ExamDetailSection.tsx
@@ -59,6 +59,7 @@ type FormData = {
   deletionStatus: ExamReviewProcessStatus | null;
   isSanctioned: boolean;
   visibilityStatus: ExamReviewProcessStatus | null;
+  memo: string | null;
   examReviewName: string;
   uploadTime: string;
   lectureName: string;
@@ -95,6 +96,7 @@ const DEFAULT_FORM_DATA: FormData = {
   deletionStatus: null,
   isSanctioned: false,
   visibilityStatus: null,
+  memo: null,
   examReviewName: '',
   uploadTime: '',
   lectureName: '',
@@ -162,6 +164,7 @@ export function ExamDetailSection({
           selectedExamReviewDetail.isSanctioned
         ),
         visibilityStatus: selectedExamReviewDetail.visibilityStatus,
+        memo: selectedExamReviewDetail.memo,
         examReviewName:
           selectedExamReviewDetail.title ??
           selectedExamReview?.reviewTitle ??
@@ -209,6 +212,7 @@ export function ExamDetailSection({
         deletionStatus: formInitialValues.deletionStatus,
         isSanctioned: formInitialValues.isSanctioned,
         visibilityStatus: formInitialValues.visibilityStatus,
+        memo: formInitialValues.memo,
         examReviewName: formInitialValues.examReviewName,
         uploadTime: formInitialValues.uploadTime,
         lectureName: formInitialValues.lectureName,

--- a/src/domains/Reviews/components/ExamDetailSection.tsx
+++ b/src/domains/Reviews/components/ExamDetailSection.tsx
@@ -146,7 +146,10 @@ export function ExamDetailSection({
         encryptedUserId: selectedExamReviewDetail.encryptedUserId,
         postId: selectedExamReviewDetail.postId,
         isConfirmed: selectedExamReviewDetail.isConfirmed,
-        examReviewName: selectedExamReviewDetail.title,
+        examReviewName:
+          selectedExamReviewDetail.title ??
+          selectedExamReview?.reviewTitle ??
+          '',
         uploadTime: uploadTimeStr,
         lectureName: selectedExamReviewDetail.lectureName,
         professorName: selectedExamReviewDetail.professor,
@@ -174,7 +177,7 @@ export function ExamDetailSection({
       };
     }
     return null;
-  }, [selectedExamReviewDetail]);
+  }, [selectedExamReview?.reviewTitle, selectedExamReviewDetail]);
 
   useEffect(() => {
     setIsEditMode(false);

--- a/src/domains/Reviews/components/ExamDetailSection.tsx
+++ b/src/domains/Reviews/components/ExamDetailSection.tsx
@@ -15,6 +15,7 @@ import {
 import {
   ExamReviewCommentSection,
   ExamReviewDetailInfoSection,
+  ExamReviewLogSection,
   ExamReviewPostInfoSection,
   ExamReviewUpdateConfirmModal,
 } from '@/domains/Reviews/components';
@@ -119,9 +120,9 @@ export function ExamDetailSection({
   onSaveSuccess,
   onDeleteSuccess,
 }: ExamDetailSectionProps = {}) {
-  const [activeTab, setActiveTab] = useState<'review' | 'post' | 'comments'>(
-    'review'
-  );
+  const [activeTab, setActiveTab] = useState<
+    'review' | 'post' | 'comments' | 'logs'
+  >('review');
   const [formData, setFormData] = useState<FormData>(DEFAULT_FORM_DATA);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -522,7 +523,7 @@ export function ExamDetailSection({
           <Tabs
             value={activeTab}
             onValueChange={(value) =>
-              setActiveTab(value as 'review' | 'post' | 'comments')
+              setActiveTab(value as 'review' | 'post' | 'comments' | 'logs')
             }
             className='w-full p-4'
           >
@@ -537,6 +538,9 @@ export function ExamDetailSection({
                   </Tabs.Trigger>
                   <Tabs.Trigger value='comments' className='w-fit'>
                     댓글 목록 ({selectedExamReviewDetail?.commentCount ?? 0})
+                  </Tabs.Trigger>
+                  <Tabs.Trigger value='logs' className='w-fit'>
+                    관리 이력 ({selectedExamReviewDetail?.logs.length ?? 0})
                   </Tabs.Trigger>
                 </Tabs.List>
                 <div className='flex items-center gap-2'>
@@ -622,6 +626,16 @@ export function ExamDetailSection({
                 <Card>
                   <Card.Content className='p-4'>
                     <ExamReviewCommentSection postId={formData.postId} />
+                  </Card.Content>
+                </Card>
+              </Tabs.Content>
+
+              <Tabs.Content value='logs' className='min-h-[460px]'>
+                <Card>
+                  <Card.Content className='p-4'>
+                    <ExamReviewLogSection
+                      logs={selectedExamReviewDetail?.logs}
+                    />
                   </Card.Content>
                 </Card>
               </Tabs.Content>

--- a/src/domains/Reviews/components/ExamDetailSection.tsx
+++ b/src/domains/Reviews/components/ExamDetailSection.tsx
@@ -540,7 +540,7 @@ export function ExamDetailSection({
                     댓글 목록 ({selectedExamReviewDetail?.commentCount ?? 0})
                   </Tabs.Trigger>
                   <Tabs.Trigger value='logs' className='w-fit'>
-                    관리 이력 ({selectedExamReviewDetail?.logs.length ?? 0})
+                    관리 이력 ({selectedExamReviewDetail?.logs?.length ?? 0})
                   </Tabs.Trigger>
                 </Tabs.List>
                 <div className='flex items-center gap-2'>

--- a/src/domains/Reviews/components/ExamDetailSection.tsx
+++ b/src/domains/Reviews/components/ExamDetailSection.tsx
@@ -21,6 +21,7 @@ import {
 import type {
   ExamReview,
   ExamReviewDetailResult,
+  ExamReviewProcessStatus,
   LectureType,
   UpdateExamReviewRequest,
 } from '@/domains/Reviews/types';
@@ -30,6 +31,7 @@ import {
   convertLectureTypeToString,
   convertSemesterEnumToString,
   convertSemesterToEnum,
+  isExamReviewSanctioned,
 } from '@/domains/Reviews/utils';
 
 import {
@@ -53,6 +55,10 @@ type FormData = {
   encryptedUserId: string;
   postId: number | null;
   isConfirmed: boolean;
+  isDiscussed: boolean;
+  deletionStatus: ExamReviewProcessStatus | null;
+  isSanctioned: boolean;
+  visibilityStatus: ExamReviewProcessStatus | null;
   examReviewName: string;
   uploadTime: string;
   lectureName: string;
@@ -85,6 +91,10 @@ const DEFAULT_FORM_DATA: FormData = {
   encryptedUserId: '',
   postId: null,
   isConfirmed: false,
+  isDiscussed: false,
+  deletionStatus: null,
+  isSanctioned: false,
+  visibilityStatus: null,
   examReviewName: '',
   uploadTime: '',
   lectureName: '',
@@ -146,6 +156,12 @@ export function ExamDetailSection({
         encryptedUserId: selectedExamReviewDetail.encryptedUserId,
         postId: selectedExamReviewDetail.postId,
         isConfirmed: selectedExamReviewDetail.isConfirmed,
+        isDiscussed: selectedExamReviewDetail.isDiscussed,
+        deletionStatus: selectedExamReviewDetail.deletionStatus,
+        isSanctioned: isExamReviewSanctioned(
+          selectedExamReviewDetail.isSanctioned
+        ),
+        visibilityStatus: selectedExamReviewDetail.visibilityStatus,
         examReviewName:
           selectedExamReviewDetail.title ??
           selectedExamReview?.reviewTitle ??
@@ -189,6 +205,10 @@ export function ExamDetailSection({
         encryptedUserId: formInitialValues.encryptedUserId,
         postId: formInitialValues.postId,
         isConfirmed: formInitialValues.isConfirmed,
+        isDiscussed: formInitialValues.isDiscussed,
+        deletionStatus: formInitialValues.deletionStatus,
+        isSanctioned: formInitialValues.isSanctioned,
+        visibilityStatus: formInitialValues.visibilityStatus,
         examReviewName: formInitialValues.examReviewName,
         uploadTime: formInitialValues.uploadTime,
         lectureName: formInitialValues.lectureName,

--- a/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
+++ b/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
@@ -19,18 +19,19 @@ import { convertLectureTypeToString } from '@/domains/Reviews/utils';
 export interface ExamReviewDetailInfoSectionFormData {
   isConfirmed: boolean;
   isDiscussed: boolean;
+  lectureName: string;
+  professorName: string;
+  lectureType: LectureType;
+  semester: string;
+  classNumber: number | null;
+  examType: string;
+  isPF: string;
+  isOnline: string;
   deletionStatus: ExamReviewProcessStatus | null;
   isSanctioned: boolean;
   visibilityStatus: ExamReviewProcessStatus | null;
-  lectureName: string;
-  professorName: string;
+  memo: string | null;
   fileName: string;
-  semester: string;
-  examType: string;
-  lectureType: LectureType;
-  classNumber: number | null;
-  isPF: string;
-  isOnline: string;
   examTypeAndQuestions: string;
 }
 
@@ -366,6 +367,14 @@ export function ExamReviewDetailInfoSection({
               rows={3}
               className='min-h-[110px] resize-none'
             />
+          </Field.Content>
+        </Field>
+        <Field className='gap-0 md:col-span-2'>
+          <Field.Label>메모</Field.Label>
+          <Field.Content>
+            <div className='min-h-[72px] rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm whitespace-pre-wrap text-gray-700'>
+              {formData.memo}
+            </div>
           </Field.Content>
         </Field>
       </div>

--- a/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
+++ b/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
@@ -1,18 +1,27 @@
 import { type RefObject } from 'react';
 
-import { Field, Input, Select, Textarea } from '@/shared/components/ui';
+import { Badge, Field, Input, Select, Textarea } from '@/shared/components/ui';
 import {
+  EXAM_REVIEW_PROCESS_STATUS,
   EXAM_TYPE_LIST,
   LECTURE_TYPE_OPTIONS,
   SEMESTER_LIST,
 } from '@/shared/constants';
+import { cn } from '@/shared/lib';
 
 import { ExamConfirmStatusBadge } from '@/domains/Reviews/components';
-import type { LectureType } from '@/domains/Reviews/types';
+import type {
+  ExamReviewProcessStatus,
+  LectureType,
+} from '@/domains/Reviews/types';
 import { convertLectureTypeToString } from '@/domains/Reviews/utils';
 
 export interface ExamReviewDetailInfoSectionFormData {
   isConfirmed: boolean;
+  isDiscussed: boolean;
+  deletionStatus: ExamReviewProcessStatus | null;
+  isSanctioned: boolean;
+  visibilityStatus: ExamReviewProcessStatus | null;
   lectureName: string;
   professorName: string;
   fileName: string;
@@ -35,6 +44,39 @@ export interface ExamReviewDetailInfoSectionProps {
   setSelectedFile: (file: File | null) => void;
 }
 
+const STATUS_FIELD_CLASS_NAME =
+  'flex min-h-9 items-center rounded-md border border-gray-200 bg-gray-50 px-3';
+
+const getProcessStatusLabel = (
+  status: ExamReviewProcessStatus | null
+): string => {
+  if (!status) {
+    return '-';
+  }
+
+  return (
+    EXAM_REVIEW_PROCESS_STATUS.find((option) => option.code === status)
+      ?.label ?? status
+  );
+};
+
+const renderStatusBadge = (
+  label: string,
+  isActive: boolean,
+  activeClassName: string
+) => (
+  <Badge
+    variant='outline'
+    className={cn(
+      'max-w-full truncate',
+      isActive ? activeClassName : 'text-gray-500 dark:text-gray-400'
+    )}
+    title={label}
+  >
+    {label}
+  </Badge>
+);
+
 export function ExamReviewDetailInfoSection({
   formData,
   setFormData,
@@ -45,6 +87,10 @@ export function ExamReviewDetailInfoSection({
   setSelectedFile,
 }: ExamReviewDetailInfoSectionProps) {
   const confirmStatus = formData.isConfirmed ? 'CONFIRMED' : 'UNCONFIRMED';
+  const deletionStatusLabel = getProcessStatusLabel(formData.deletionStatus);
+  const visibilityStatusLabel = getProcessStatusLabel(
+    formData.visibilityStatus
+  );
 
   return (
     <div className='space-y-4'>
@@ -71,6 +117,56 @@ export function ExamReviewDetailInfoSection({
                 </Select.Item>
               </Select.Content>
             </Select>
+          </Field.Content>
+        </Field>
+        <Field className='gap-0'>
+          <Field.Label>논의 여부</Field.Label>
+          <Field.Content>
+            <div className={STATUS_FIELD_CLASS_NAME}>
+              {renderStatusBadge(
+                formData.isDiscussed ? '논의 있음' : '논의 없음',
+                formData.isDiscussed,
+                'border-blue-200 bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300'
+              )}
+            </div>
+          </Field.Content>
+        </Field>
+        <Field className='gap-0'>
+          <Field.Label>삭제 상태</Field.Label>
+          <Field.Content>
+            <div className={STATUS_FIELD_CLASS_NAME}>
+              {renderStatusBadge(
+                deletionStatusLabel,
+                formData.deletionStatus !== null &&
+                  formData.deletionStatus !== 'VISIBLE',
+                'border-red-200 bg-red-50 text-red-700 dark:bg-red-950 dark:text-red-300'
+              )}
+            </div>
+          </Field.Content>
+        </Field>
+        <Field className='gap-0'>
+          <Field.Label>징계 여부</Field.Label>
+          <Field.Content>
+            <div className={STATUS_FIELD_CLASS_NAME}>
+              {renderStatusBadge(
+                formData.isSanctioned ? '징계' : '징계 없음',
+                formData.isSanctioned,
+                'border-rose-200 bg-rose-50 text-rose-700 dark:bg-rose-950 dark:text-rose-300'
+              )}
+            </div>
+          </Field.Content>
+        </Field>
+        <Field className='gap-0'>
+          <Field.Label>공개 상태</Field.Label>
+          <Field.Content>
+            <div className={STATUS_FIELD_CLASS_NAME}>
+              {renderStatusBadge(
+                visibilityStatusLabel,
+                formData.visibilityStatus !== null &&
+                  formData.visibilityStatus !== 'VISIBLE',
+                'border-amber-200 bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-300'
+              )}
+            </div>
           </Field.Content>
         </Field>
         <Field className='gap-0'>

--- a/src/domains/Reviews/components/ExamReviewLogSection.tsx
+++ b/src/domains/Reviews/components/ExamReviewLogSection.tsx
@@ -8,7 +8,7 @@ import { formatDateTimeToMinutes } from '@/shared/utils';
 import type { ExamReviewDetailLog } from '@/domains/Reviews/types';
 
 interface ExamReviewLogSectionProps {
-  logs?: ExamReviewDetailLog[];
+  logs?: ExamReviewDetailLog[] | null;
 }
 
 const CHANGE_FIELD_LABELS: Record<string, string> = {
@@ -81,8 +81,10 @@ const formatChangeValue = (
   return String(value);
 };
 
-export function ExamReviewLogSection({ logs = [] }: ExamReviewLogSectionProps) {
-  if (logs.length === 0) {
+export function ExamReviewLogSection({ logs }: ExamReviewLogSectionProps) {
+  const safeLogs = logs ?? [];
+
+  if (safeLogs.length === 0) {
     return (
       <div className='flex min-h-[240px] items-center justify-center rounded-md border border-gray-200 bg-gray-50 text-sm text-gray-500'>
         관리 이력이 없습니다.
@@ -106,7 +108,7 @@ export function ExamReviewLogSection({ logs = [] }: ExamReviewLogSectionProps) {
           </Table.Row>
         </Table.Header>
         <Table.Body>
-          {logs.map((log, index) => (
+          {safeLogs.map((log, index) => (
             <Table.Row key={`${log.createdAt}-${index}`}>
               <Table.Cell>{formatDateTimeToMinutes(log.createdAt)}</Table.Cell>
               <Table.Cell>{log.adminName || '-'}</Table.Cell>

--- a/src/domains/Reviews/components/ExamReviewLogSection.tsx
+++ b/src/domains/Reviews/components/ExamReviewLogSection.tsx
@@ -1,0 +1,139 @@
+import { Badge, Table } from '@/shared/components/ui';
+import {
+  EXAM_CONFIRM_STATUS,
+  EXAM_REVIEW_PROCESS_STATUS,
+} from '@/shared/constants';
+import { formatDateTimeToMinutes } from '@/shared/utils';
+
+import type { ExamReviewDetailLog } from '@/domains/Reviews/types';
+
+interface ExamReviewLogSectionProps {
+  logs?: ExamReviewDetailLog[];
+}
+
+const CHANGE_FIELD_LABELS: Record<string, string> = {
+  action: '작업',
+  status: '상태',
+  statusModifiedReason: '변경 이유',
+  isConfirmed: '확인여부',
+  isDiscussed: '논의여부',
+  lectureName: '강의명',
+  professor: '교수명',
+  lectureType: '강의종류',
+  lectureYear: '강의연도',
+  semester: '수강학기',
+  classNumber: '분반',
+  examType: '시험종류',
+  isPF: 'P/F',
+  isOnline: '온라인 여부',
+  questionDetail: '시험 유형 및 문항수',
+  deletionStatus: '삭제 상태',
+  isSanctioned: '징계 여부',
+  visibilityStatus: '공개 상태',
+  memo: '메모',
+  fileName: '파일명',
+};
+
+const ACTION_LABELS: Record<string, string> = {
+  CREATED: '생성',
+  UPDATED: '수정',
+  DELETED: '삭제',
+  CONFIRMED: '확인',
+  UNCONFIRMED: '미확인',
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  ...Object.fromEntries(
+    EXAM_CONFIRM_STATUS.map(({ code, label }) => [code, label])
+  ),
+  ...Object.fromEntries(
+    EXAM_REVIEW_PROCESS_STATUS.map(({ code, label }) => [code, label])
+  ),
+};
+
+const formatStatusValue = (value: string): string =>
+  value
+    .split(/\s*->\s*/)
+    .map((status) => STATUS_LABELS[status] ?? status)
+    .join(' -> ');
+
+const formatChangeValue = (
+  key: string,
+  value: string | number | boolean | null
+): string => {
+  if (value === null) {
+    return '-';
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+
+  if (key === 'action') {
+    const actionValue = String(value);
+    return ACTION_LABELS[actionValue] ?? actionValue;
+  }
+
+  if (key === 'status') {
+    return formatStatusValue(String(value));
+  }
+
+  return String(value);
+};
+
+export function ExamReviewLogSection({ logs = [] }: ExamReviewLogSectionProps) {
+  if (logs.length === 0) {
+    return (
+      <div className='flex min-h-[240px] items-center justify-center rounded-md border border-gray-200 bg-gray-50 text-sm text-gray-500'>
+        관리 이력이 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className='overflow-hidden rounded-md border border-gray-200'>
+      <Table className='table-fixed bg-white'>
+        <colgroup>
+          <col className='w-[150px]' />
+          <col className='w-[120px]' />
+          <col className='w-full' />
+        </colgroup>
+        <Table.Header className='bg-gray-100'>
+          <Table.Row>
+            <Table.Head>변경일시</Table.Head>
+            <Table.Head>관리자</Table.Head>
+            <Table.Head className='w-full'>변경 내용</Table.Head>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {logs.map((log, index) => (
+            <Table.Row key={`${log.createdAt}-${index}`}>
+              <Table.Cell>{formatDateTimeToMinutes(log.createdAt)}</Table.Cell>
+              <Table.Cell>{log.adminName || '-'}</Table.Cell>
+              <Table.Cell className='whitespace-normal'>
+                <div className='flex flex-col gap-1.5'>
+                  {Object.entries(log.changes).map(([key, value]) => (
+                    <div
+                      key={key}
+                      className='flex flex-wrap items-center gap-2'
+                    >
+                      <Badge
+                        variant='outline'
+                        className='bg-gray-50 text-gray-700'
+                      >
+                        {CHANGE_FIELD_LABELS[key] ?? key}
+                      </Badge>
+                      <span className='text-sm break-all text-gray-700'>
+                        {formatChangeValue(key, value)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+    </div>
+  );
+}

--- a/src/domains/Reviews/components/ExamReviewLogSection.tsx
+++ b/src/domains/Reviews/components/ExamReviewLogSection.tsx
@@ -59,7 +59,8 @@ const formatStatusValue = (value: string): string =>
 
 const formatChangeValue = (
   key: string,
-  value: string | number | boolean | null
+  value: string | number | boolean | null,
+  statusModifiedReason?: string | number | boolean | null
 ): string => {
   if (value === null) {
     return '-';
@@ -75,11 +76,19 @@ const formatChangeValue = (
   }
 
   if (key === 'status') {
-    return formatStatusValue(String(value));
+    const formattedStatus = formatStatusValue(String(value));
+    return statusModifiedReason
+      ? `${formattedStatus} (${String(statusModifiedReason)})`
+      : formattedStatus;
   }
 
   return String(value);
 };
+
+const getVisibleChanges = (changes?: ExamReviewDetailLog['changes'] | null) =>
+  Object.entries(changes ?? {}).filter(
+    ([key]) => key !== 'statusModifiedReason'
+  );
 
 export function ExamReviewLogSection({ logs }: ExamReviewLogSectionProps) {
   const safeLogs = logs ?? [];
@@ -114,7 +123,7 @@ export function ExamReviewLogSection({ logs }: ExamReviewLogSectionProps) {
               <Table.Cell>{log.adminName || '-'}</Table.Cell>
               <Table.Cell className='whitespace-normal'>
                 <div className='flex flex-col gap-1.5'>
-                  {Object.entries(log.changes).map(([key, value]) => (
+                  {getVisibleChanges(log.changes).map(([key, value]) => (
                     <div
                       key={key}
                       className='flex flex-wrap items-center gap-2'
@@ -126,7 +135,11 @@ export function ExamReviewLogSection({ logs }: ExamReviewLogSectionProps) {
                         {CHANGE_FIELD_LABELS[key] ?? key}
                       </Badge>
                       <span className='text-sm break-all text-gray-700'>
-                        {formatChangeValue(key, value)}
+                        {formatChangeValue(
+                          key,
+                          value,
+                          log.changes?.statusModifiedReason
+                        )}
                       </span>
                     </div>
                   ))}

--- a/src/domains/Reviews/components/index.ts
+++ b/src/domains/Reviews/components/index.ts
@@ -6,6 +6,7 @@ export { default as ExamDiscussionPanel } from './ExamDiscussionPanel';
 export { ExamMultiSelect } from './ExamMultiSelect';
 export { ExamReviewCommentSection } from './ExamReviewCommentSection';
 export { ExamReviewDetailInfoSection } from './ExamReviewDetailInfoSection';
+export { ExamReviewLogSection } from './ExamReviewLogSection';
 export { ExamReviewPeriodDeleteConfirmModal } from './ExamReviewPeriodDeleteConfirmModal';
 export { ExamReviewPeriodListSection } from './ExamReviewPeriodListSection';
 export { ExamReviewPeriodScheduleForm } from './ExamReviewPeriodScheduleForm';

--- a/src/domains/Reviews/hooks/use-exam-reviews.ts
+++ b/src/domains/Reviews/hooks/use-exam-reviews.ts
@@ -5,13 +5,13 @@ import { formatDateTimeToMinutes } from '@/shared/utils';
 import { STATUS } from '@/domains/Reviews/constants';
 import type {
   ExamReview,
-  ExamReviewProcessStatus,
   ExamReviewSearchParams,
   ExamReviews,
 } from '@/domains/Reviews/types';
 import {
   convertExamTypeEnumToString,
   convertSemesterEnumToString,
+  getExamReviewProcessStatuses,
 } from '@/domains/Reviews/utils';
 
 import { getExamReviews } from '@/apis';
@@ -21,29 +21,6 @@ interface UseExamReviewsParams extends ExamReviewSearchParams {
   enabled?: boolean;
   refreshKey?: number;
 }
-
-const isSanctioned = (value: ExamReviews['isSanctioned']): boolean =>
-  value === true || value === 'true';
-
-const getProcessStatuses = (
-  apiData: ExamReviews
-): ExamReviewProcessStatus[] => {
-  const processStatuses: ExamReviewProcessStatus[] = [];
-
-  if (apiData.deletionStatus && apiData.deletionStatus !== 'VISIBLE') {
-    processStatuses.push(apiData.deletionStatus);
-  }
-
-  if (apiData.visibilityStatus && apiData.visibilityStatus !== 'VISIBLE') {
-    processStatuses.push(apiData.visibilityStatus);
-  }
-
-  if (isSanctioned(apiData.isSanctioned)) {
-    processStatuses.push('SANCTIONED');
-  }
-
-  return processStatuses.length > 0 ? processStatuses : ['VISIBLE'];
-};
 
 const transformApiResponseToExamReview = (apiData: ExamReviews): ExamReview => {
   const reviewTitle = apiData.title || apiData.content || '';
@@ -85,7 +62,7 @@ const transformApiResponseToExamReview = (apiData: ExamReviews): ExamReview => {
     isDiscussed: apiData.isDiscussed ?? false,
     isReported: reportCount > 0,
     reportCount,
-    processStatuses: getProcessStatuses(apiData),
+    processStatuses: getExamReviewProcessStatuses(apiData),
   };
 };
 

--- a/src/domains/Reviews/types/exam.ts
+++ b/src/domains/Reviews/types/exam.ts
@@ -173,7 +173,7 @@ export interface ExamReviewDetailResult {
   memo: string | null;
   fileName: string;
   questionDetail: string;
-  logs: ExamReviewDetailLog[];
+  logs: ExamReviewDetailLog[] | null;
 }
 
 export interface ExamReviewDetailResponse {

--- a/src/domains/Reviews/types/exam.ts
+++ b/src/domains/Reviews/types/exam.ts
@@ -141,20 +141,21 @@ export interface DeleteExamReviewResponse {
   };
 }
 
+export interface ExamReviewDetailLog {
+  encryptedAdminId: string | null;
+  adminName: string | null;
+  changes: Record<string, string | number | boolean | null>;
+  createdAt: string;
+}
+
 export interface ExamReviewDetailResult {
   encryptedUserId: string;
   userDisplay: string;
-  isWriter: boolean;
-  isWriterWithdrawn: boolean;
   postId: number;
-  title: string;
+  title?: string;
   commentCount: number;
-  scrapCount: number;
-  isScrapped: boolean;
   status?: string;
   createdAt: string;
-  isNotice: boolean;
-  isEdited: boolean;
   lectureName: string;
   professor: string;
   classNumber: number;
@@ -165,9 +166,14 @@ export interface ExamReviewDetailResult {
   isOnline: boolean;
   examType: ExamType;
   isConfirmed: boolean;
+  isDiscussed: boolean;
+  deletionStatus: ExamReviewProcessStatus | null;
+  isSanctioned: boolean | 'true' | 'false' | null;
+  visibilityStatus: ExamReviewProcessStatus | null;
+  memo: string | null;
   fileName: string;
   questionDetail: string;
-  isDownloaded: boolean;
+  logs: ExamReviewDetailLog[];
 }
 
 export interface ExamReviewDetailResponse {

--- a/src/domains/Reviews/types/exam.ts
+++ b/src/domains/Reviews/types/exam.ts
@@ -144,7 +144,7 @@ export interface DeleteExamReviewResponse {
 export interface ExamReviewDetailLog {
   encryptedAdminId: string | null;
   adminName: string | null;
-  changes: Record<string, string | number | boolean | null>;
+  changes?: Record<string, string | number | boolean | null> | null;
   createdAt: string;
 }
 

--- a/src/domains/Reviews/types/index.ts
+++ b/src/domains/Reviews/types/index.ts
@@ -3,6 +3,7 @@ export type {
   ConfirmExamReviewResponse,
   DeleteExamReviewResponse,
   ExamReview,
+  ExamReviewDetailLog,
   ExamReviewDetailResponse,
   ExamReviewDetailResult,
   ExamReviewProcessStatus,

--- a/src/domains/Reviews/utils/exam-formatters.ts
+++ b/src/domains/Reviews/utils/exam-formatters.ts
@@ -1,5 +1,37 @@
 import { EXAM_CONFIRM_STATUS } from '@/shared/constants';
 
+import type { ExamReviewProcessStatus } from '@/domains/Reviews/types';
+
+interface ExamReviewProcessStatusSource {
+  deletionStatus?: ExamReviewProcessStatus | null;
+  visibilityStatus?: ExamReviewProcessStatus | null;
+  isSanctioned?: boolean | 'true' | 'false' | null;
+}
+
+export const isExamReviewSanctioned = (
+  value: ExamReviewProcessStatusSource['isSanctioned']
+): boolean => value === true || value === 'true';
+
+export const getExamReviewProcessStatuses = (
+  source: ExamReviewProcessStatusSource
+): ExamReviewProcessStatus[] => {
+  const processStatuses: ExamReviewProcessStatus[] = [];
+
+  if (source.deletionStatus && source.deletionStatus !== 'VISIBLE') {
+    processStatuses.push(source.deletionStatus);
+  }
+
+  if (source.visibilityStatus && source.visibilityStatus !== 'VISIBLE') {
+    processStatuses.push(source.visibilityStatus);
+  }
+
+  if (isExamReviewSanctioned(source.isSanctioned)) {
+    processStatuses.push('SANCTIONED');
+  }
+
+  return processStatuses.length > 0 ? processStatuses : ['VISIBLE'];
+};
+
 /**
  * lectureType enum을 문자열로 변환
  * @param lectureTypeEnum - 변환할 lectureType enum 값

--- a/src/domains/Reviews/utils/index.ts
+++ b/src/domains/Reviews/utils/index.ts
@@ -5,5 +5,7 @@ export {
   convertSemesterEnumToString,
   convertSemesterToEnum,
   extractYearFromSemester,
+  getExamReviewProcessStatuses,
   getStatusName,
+  isExamReviewSanctioned,
 } from './exam-formatters';

--- a/src/pages/reviews/ExamReviewPage.tsx
+++ b/src/pages/reviews/ExamReviewPage.tsx
@@ -23,6 +23,7 @@ import type {
 import {
   convertExamTypeEnumToString,
   convertSemesterEnumToString,
+  getExamReviewProcessStatuses,
 } from '@/domains/Reviews/utils';
 
 import { getExamReviewDetail } from '@/apis';
@@ -277,7 +278,8 @@ export default function ExamReviewPage() {
                   nextStatus ??
                   updatedDetail.status ??
                   (updatedDetail.isConfirmed ? 'CONFIRMED' : 'UNCONFIRMED'),
-                reviewTitle: updatedDetail.title,
+                reviewTitle:
+                  updatedDetail.title ?? selectedExamReview.reviewTitle,
                 courseName,
                 professor,
                 semester,
@@ -286,10 +288,10 @@ export default function ExamReviewPage() {
                 questionDetail: updatedDetail.questionDetail,
                 uploadTime,
                 userDisplay: updatedDetail.userDisplay,
-                isDiscussed: selectedExamReview.isDiscussed,
+                isDiscussed: updatedDetail.isDiscussed,
                 isReported: selectedExamReview.isReported,
                 reportCount: selectedExamReview.reportCount,
-                processStatuses: selectedExamReview.processStatuses,
+                processStatuses: getExamReviewProcessStatuses(updatedDetail),
               };
 
               updatedData[itemIndex] = updatedItem;


### PR DESCRIPTION
## 🔎 What is this PR?

Close #269


## 🎯 변경 사항

###### 주요 변경점을 설명해주세요.

  - 시험후기 상세 조회 API를 `/v1/admin/reviews/{postId}`로 변경
  - 변경된 상세 조회 응답에 맞춰 타입 수정
    - `isDiscussed`
    - `deletionStatus`
    - `isSanctioned`
    - `visibilityStatus`
    - `memo`
    - `logs`
  - 시험후기 상세정보 탭에 논의 여부, 삭제 상태, 징계 여부, 공개 상태, 메모를 추가
  - 관리 이력 탭을 추가해 관리자 변경 로그를 확인하는 기능 추가
  - 관리 이력의 `status` 값은 한글 상태명으로 표시하고, `statusModifiedReason`은 상태 뒤 괄호 안에 함께 표시되도록 처리
  - 목록/상세에서 공통으로 사용하는 처리상태 계산 로직을 유틸로 분리

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
