### PR TITLE
merge: 시험후기 관련 기능 배포 (2026-06-20)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
     <link
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
       rel="stylesheet"

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,2 @@
+/*
+  X-Robots-Tag: noindex, nofollow

--- a/src/apis/reviews.ts
+++ b/src/apis/reviews.ts
@@ -55,7 +55,12 @@ export const updateExamReview = async (
 
   const response = await axiosInstance.patch(
     `/v1/admin/reviews/${postId}`,
-    formData
+    formData,
+    {
+      headers: {
+        'Content-Type': undefined,
+      },
+    }
   );
   return response.data;
 };

--- a/src/apis/reviews.ts
+++ b/src/apis/reviews.ts
@@ -74,7 +74,7 @@ export const deleteExamReview = async (
 export const getExamReviewDetail = async (
   postId: number
 ): Promise<ExamReviewDetailResponse> => {
-  const response = await axiosInstance.get(`/v1/reviews/${postId}`);
+  const response = await axiosInstance.get(`/v1/admin/reviews/${postId}`);
   return response.data;
 };
 

--- a/src/apis/reviews.ts
+++ b/src/apis/reviews.ts
@@ -9,25 +9,16 @@ import type {
   ConfirmExamReviewResponse,
   DeleteExamReviewResponse,
   ExamReviewDetailResponse,
+  ExamReviewSearchParams,
   ExamReviewsResponse,
   UpdateExamReviewRequest,
   UpdateExamReviewResponse,
 } from '@/domains/Reviews/types';
 
 // 시험후기 목록 조회 api
-export const getExamReviews = async (params: {
-  page: number;
-  keyword?: string;
-  startDate?: string;
-  endDate?: string;
-  keywordAuthor?: string;
-  keywordPost?: string;
-  sort?: string;
-  lectureYear?: number;
-  semester?: string;
-  examType?: string;
-  isConfirmed?: boolean;
-}): Promise<ExamReviewsResponse> => {
+export const getExamReviews = async (
+  params: ExamReviewSearchParams & { page: number }
+): Promise<ExamReviewsResponse> => {
   const response = await axiosInstance.get(`/v1/admin/reviews`, {
     params,
   });

--- a/src/apis/reviews.ts
+++ b/src/apis/reviews.ts
@@ -48,16 +48,14 @@ export const updateExamReview = async (
     formData.append('file', data.file); // 파일이 있으면 추가
   }
 
-  formData.append('post', JSON.stringify(data.post));
+  formData.append(
+    'post',
+    new Blob([JSON.stringify(data.post)], { type: 'application/json' })
+  );
 
   const response = await axiosInstance.patch(
     `/v1/admin/reviews/${postId}`,
-    formData,
-    {
-      headers: {
-        'Content-Type': undefined,
-      },
-    }
+    formData
   );
   return response.data;
 };

--- a/src/domains/Reviews/components/ExamDetailSection.tsx
+++ b/src/domains/Reviews/components/ExamDetailSection.tsx
@@ -36,7 +36,6 @@ import {
 } from '@/domains/Reviews/utils';
 
 import {
-  confirmExamReview,
   deleteExamReview,
   downloadExamReviewFile,
   updateExamReview,
@@ -48,7 +47,7 @@ interface ExamDetailSectionProps {
   selectedExamReview?: ExamReview | null;
   selectedExamReviewDetail?: ExamReviewDetailResult | null;
   isLoadingDetail?: boolean;
-  onSaveSuccess?: (status?: string) => void;
+  onSaveSuccess?: (updatedDetail?: ExamReviewDetailResult) => void;
   onDeleteSuccess?: () => void;
 }
 
@@ -78,6 +77,8 @@ type FormData = {
 
 type InitialValues = {
   isConfirmed: boolean;
+  isDiscussed: boolean;
+  memo: string | null;
   lectureName: string;
   professorName: string;
   classNumber: number | null;
@@ -87,6 +88,7 @@ type InitialValues = {
   isOnline: string;
   examType: string;
   questionDetail: string;
+  fileName: string;
 };
 
 const DEFAULT_FORM_DATA: FormData = {
@@ -184,6 +186,8 @@ export function ExamDetailSection({
         author: selectedExamReviewDetail.userDisplay,
         initialValues: {
           isConfirmed: selectedExamReviewDetail.isConfirmed,
+          isDiscussed: selectedExamReviewDetail.isDiscussed,
+          memo: selectedExamReviewDetail.memo,
           lectureName: selectedExamReviewDetail.lectureName,
           professorName: selectedExamReviewDetail.professor,
           classNumber: selectedExamReviewDetail.classNumber,
@@ -193,6 +197,7 @@ export function ExamDetailSection({
           isOnline: selectedExamReviewDetail.isOnline ? 'O' : 'X',
           examType: examTypeStr,
           questionDetail: selectedExamReviewDetail.questionDetail,
+          fileName: selectedExamReviewDetail.fileName,
         },
       };
     }
@@ -240,6 +245,8 @@ export function ExamDetailSection({
     if (!initialValues) return false;
     return (
       formData.isConfirmed !== initialValues.isConfirmed ||
+      formData.isDiscussed !== initialValues.isDiscussed ||
+      (formData.memo ?? '') !== (initialValues.memo ?? '') ||
       formData.lectureName !== initialValues.lectureName ||
       formData.professorName !== initialValues.professorName ||
       formData.classNumber !== initialValues.classNumber ||
@@ -267,6 +274,11 @@ export function ExamDetailSection({
       initialValues.isConfirmed ? '확인' : '미확인',
       formData.isConfirmed ? '확인' : '미확인'
     );
+    add(
+      '논의 여부',
+      initialValues.isDiscussed ? '논의 있음' : '논의 없음',
+      formData.isDiscussed ? '논의 있음' : '논의 없음'
+    );
 
     add('강의명', initialValues.lectureName, formData.lectureName);
     add('교수명', initialValues.professorName, formData.professorName);
@@ -289,9 +301,10 @@ export function ExamDetailSection({
       initialValues.questionDetail,
       formData.examTypeAndQuestions
     );
+    add('메모', initialValues.memo ?? '', formData.memo ?? '');
 
     if (selectedFile) {
-      add('업로드 파일', formData.fileName || '', selectedFile.name);
+      add('업로드 파일', initialValues.fileName || '', selectedFile.name);
     }
 
     return changes;
@@ -304,6 +317,8 @@ export function ExamDetailSection({
         encryptedUserId: selectedExamReviewDetail.encryptedUserId,
         postId: selectedExamReviewDetail.postId,
         isConfirmed: initialValues.isConfirmed,
+        isDiscussed: initialValues.isDiscussed,
+        memo: initialValues.memo,
         lectureName: initialValues.lectureName,
         professorName: initialValues.professorName,
         classNumber: initialValues.classNumber,
@@ -313,7 +328,7 @@ export function ExamDetailSection({
         isOnline: initialValues.isOnline,
         examType: initialValues.examType,
         examTypeAndQuestions: initialValues.questionDetail,
-        fileName: selectedExamReviewDetail.fileName,
+        fileName: initialValues.fileName,
       }));
       setSelectedFile(null);
     }
@@ -366,6 +381,19 @@ export function ExamDetailSection({
     try {
       const post: UpdateExamReviewRequest['post'] = {};
 
+      if (formData.classNumber === null) {
+        toast.error('분반을 입력해주세요.');
+        return;
+      }
+      if (formData.isConfirmed !== initialValues.isConfirmed) {
+        post.isConfirmed = formData.isConfirmed;
+      }
+      if (formData.isDiscussed !== initialValues.isDiscussed) {
+        post.isDiscussed = formData.isDiscussed;
+      }
+      if ((formData.memo ?? '') !== (initialValues.memo ?? '')) {
+        post.memo = formData.memo === '' ? null : formData.memo;
+      }
       if (formData.lectureName !== initialValues.lectureName) {
         post.lectureName = formData.lectureName;
       }
@@ -373,9 +401,7 @@ export function ExamDetailSection({
         post.professor = formData.professorName;
       }
       if (formData.classNumber !== initialValues.classNumber) {
-        if (formData.classNumber !== null) {
-          post.classNumber = formData.classNumber;
-        }
+        post.classNumber = formData.classNumber;
       }
       if (formData.semester !== initialValues.semester) {
         const yearMatch = formData.semester.match(/^(\d{4})/);
@@ -401,36 +427,25 @@ export function ExamDetailSection({
         post.questionDetail = formData.examTypeAndQuestions;
       }
 
-      const hasReviewUpdate = Object.keys(post).length > 0 || selectedFile;
-      const hasConfirmUpdate =
-        formData.isConfirmed !== initialValues.isConfirmed;
+      const hasUpdate = Object.keys(post).length > 0 || selectedFile;
 
-      if (hasReviewUpdate) {
-        const updateData: UpdateExamReviewRequest = {
-          ...(selectedFile ? { file: selectedFile } : {}),
-          post,
-        };
-
-        const response = await updateExamReview(
-          selectedExamReview.id,
-          updateData
-        );
-
-        if (!response.isSuccess) {
-          toast.error(response.message || '시험 후기 수정에 실패했습니다.');
-          return;
-        }
+      if (!hasUpdate) {
+        return;
       }
 
-      if (hasConfirmUpdate) {
-        const response = await confirmExamReview(selectedExamReview.id, {
-          isConfirmed: formData.isConfirmed,
-        });
+      const updateData: UpdateExamReviewRequest = {
+        ...(selectedFile ? { file: selectedFile } : {}),
+        post,
+      };
 
-        if (!response.isSuccess) {
-          toast.error(response.message || '확인여부 변경에 실패했습니다.');
-          return;
-        }
+      const response = await updateExamReview(
+        selectedExamReview.id,
+        updateData
+      );
+
+      if (!response.isSuccess) {
+        toast.error(response.message || '시험 후기 수정에 실패했습니다.');
+        return;
       }
 
       toast.success('시험 후기가 성공적으로 수정되었습니다.');
@@ -438,6 +453,8 @@ export function ExamDetailSection({
       setIsEditMode(false);
       setInitialValues({
         isConfirmed: formData.isConfirmed,
+        isDiscussed: response.result.isDiscussed,
+        memo: response.result.memo,
         lectureName: formData.lectureName,
         professorName: formData.professorName,
         classNumber: formData.classNumber,
@@ -447,8 +464,9 @@ export function ExamDetailSection({
         isOnline: formData.isOnline,
         examType: formData.examType,
         questionDetail: formData.examTypeAndQuestions,
+        fileName: response.result.fileName,
       });
-      onSaveSuccess?.();
+      onSaveSuccess?.(response.result);
     } catch (error: unknown) {
       const errorMessage =
         (isAxiosError(error) && error.response?.data?.message) ||

--- a/src/domains/Reviews/components/ExamDetailSection.tsx
+++ b/src/domains/Reviews/components/ExamDetailSection.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/domains/Reviews/utils';
 
 import {
+  confirmExamReview,
   deleteExamReview,
   downloadExamReviewFile,
   updateExamReview,
@@ -385,9 +386,6 @@ export function ExamDetailSection({
         toast.error('분반을 입력해주세요.');
         return;
       }
-      if (formData.isConfirmed !== initialValues.isConfirmed) {
-        post.isConfirmed = formData.isConfirmed;
-      }
       if (formData.isDiscussed !== initialValues.isDiscussed) {
         post.isDiscussed = formData.isDiscussed;
       }
@@ -427,34 +425,60 @@ export function ExamDetailSection({
         post.questionDetail = formData.examTypeAndQuestions;
       }
 
-      const hasUpdate = Object.keys(post).length > 0 || selectedFile;
+      const hasConfirmUpdate =
+        formData.isConfirmed !== initialValues.isConfirmed;
+      const hasDetailUpdate =
+        Object.keys(post).length > 0 || Boolean(selectedFile);
 
-      if (!hasUpdate) {
+      if (!hasConfirmUpdate && !hasDetailUpdate) {
         return;
       }
 
-      const updateData: UpdateExamReviewRequest = {
-        ...(selectedFile ? { file: selectedFile } : {}),
-        post,
-      };
+      let updatedDetail: ExamReviewDetailResult = selectedExamReviewDetail;
 
-      const response = await updateExamReview(
-        selectedExamReview.id,
-        updateData
-      );
+      if (hasDetailUpdate) {
+        const updateData: UpdateExamReviewRequest = {
+          ...(selectedFile ? { file: selectedFile } : {}),
+          post,
+        };
 
-      if (!response.isSuccess) {
-        toast.error(response.message || '시험 후기 수정에 실패했습니다.');
-        return;
+        const response = await updateExamReview(
+          selectedExamReview.id,
+          updateData
+        );
+
+        if (!response.isSuccess) {
+          toast.error(response.message || '시험 후기 수정에 실패했습니다.');
+          return;
+        }
+
+        updatedDetail = response.result;
+      }
+
+      if (hasConfirmUpdate) {
+        const response = await confirmExamReview(selectedExamReview.id, {
+          isConfirmed: formData.isConfirmed,
+        });
+
+        if (!response.isSuccess) {
+          toast.error(response.message || '시험 후기 확인처리에 실패했습니다.');
+          return;
+        }
+
+        updatedDetail = {
+          ...updatedDetail,
+          isConfirmed: response.result.isConfirmed,
+          status: response.result.isConfirmed ? 'CONFIRMED' : 'UNCONFIRMED',
+        };
       }
 
       toast.success('시험 후기가 성공적으로 수정되었습니다.');
       setSelectedFile(null);
       setIsEditMode(false);
       setInitialValues({
-        isConfirmed: formData.isConfirmed,
-        isDiscussed: response.result.isDiscussed,
-        memo: response.result.memo,
+        isConfirmed: updatedDetail.isConfirmed,
+        isDiscussed: updatedDetail.isDiscussed,
+        memo: updatedDetail.memo,
         lectureName: formData.lectureName,
         professorName: formData.professorName,
         classNumber: formData.classNumber,
@@ -464,9 +488,9 @@ export function ExamDetailSection({
         isOnline: formData.isOnline,
         examType: formData.examType,
         questionDetail: formData.examTypeAndQuestions,
-        fileName: response.result.fileName,
+        fileName: updatedDetail.fileName,
       });
-      onSaveSuccess?.(response.result);
+      onSaveSuccess?.(updatedDetail);
     } catch (error: unknown) {
       const errorMessage =
         (isAxiosError(error) && error.response?.data?.message) ||

--- a/src/domains/Reviews/components/ExamDetailSection.tsx
+++ b/src/domains/Reviews/components/ExamDetailSection.tsx
@@ -15,12 +15,14 @@ import {
 import {
   ExamReviewCommentSection,
   ExamReviewDetailInfoSection,
+  ExamReviewLogSection,
   ExamReviewPostInfoSection,
   ExamReviewUpdateConfirmModal,
 } from '@/domains/Reviews/components';
 import type {
   ExamReview,
   ExamReviewDetailResult,
+  ExamReviewProcessStatus,
   LectureType,
   UpdateExamReviewRequest,
 } from '@/domains/Reviews/types';
@@ -30,6 +32,7 @@ import {
   convertLectureTypeToString,
   convertSemesterEnumToString,
   convertSemesterToEnum,
+  isExamReviewSanctioned,
 } from '@/domains/Reviews/utils';
 
 import {
@@ -53,6 +56,11 @@ type FormData = {
   encryptedUserId: string;
   postId: number | null;
   isConfirmed: boolean;
+  isDiscussed: boolean;
+  deletionStatus: ExamReviewProcessStatus | null;
+  isSanctioned: boolean;
+  visibilityStatus: ExamReviewProcessStatus | null;
+  memo: string | null;
   examReviewName: string;
   uploadTime: string;
   lectureName: string;
@@ -85,6 +93,11 @@ const DEFAULT_FORM_DATA: FormData = {
   encryptedUserId: '',
   postId: null,
   isConfirmed: false,
+  isDiscussed: false,
+  deletionStatus: null,
+  isSanctioned: false,
+  visibilityStatus: null,
+  memo: null,
   examReviewName: '',
   uploadTime: '',
   lectureName: '',
@@ -107,9 +120,9 @@ export function ExamDetailSection({
   onSaveSuccess,
   onDeleteSuccess,
 }: ExamDetailSectionProps = {}) {
-  const [activeTab, setActiveTab] = useState<'review' | 'post' | 'comments'>(
-    'review'
-  );
+  const [activeTab, setActiveTab] = useState<
+    'review' | 'post' | 'comments' | 'logs'
+  >('review');
   const [formData, setFormData] = useState<FormData>(DEFAULT_FORM_DATA);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -146,7 +159,17 @@ export function ExamDetailSection({
         encryptedUserId: selectedExamReviewDetail.encryptedUserId,
         postId: selectedExamReviewDetail.postId,
         isConfirmed: selectedExamReviewDetail.isConfirmed,
-        examReviewName: selectedExamReviewDetail.title,
+        isDiscussed: selectedExamReviewDetail.isDiscussed,
+        deletionStatus: selectedExamReviewDetail.deletionStatus,
+        isSanctioned: isExamReviewSanctioned(
+          selectedExamReviewDetail.isSanctioned
+        ),
+        visibilityStatus: selectedExamReviewDetail.visibilityStatus,
+        memo: selectedExamReviewDetail.memo,
+        examReviewName:
+          selectedExamReviewDetail.title ??
+          selectedExamReview?.reviewTitle ??
+          '',
         uploadTime: uploadTimeStr,
         lectureName: selectedExamReviewDetail.lectureName,
         professorName: selectedExamReviewDetail.professor,
@@ -174,7 +197,7 @@ export function ExamDetailSection({
       };
     }
     return null;
-  }, [selectedExamReviewDetail]);
+  }, [selectedExamReview?.reviewTitle, selectedExamReviewDetail]);
 
   useEffect(() => {
     setIsEditMode(false);
@@ -186,6 +209,11 @@ export function ExamDetailSection({
         encryptedUserId: formInitialValues.encryptedUserId,
         postId: formInitialValues.postId,
         isConfirmed: formInitialValues.isConfirmed,
+        isDiscussed: formInitialValues.isDiscussed,
+        deletionStatus: formInitialValues.deletionStatus,
+        isSanctioned: formInitialValues.isSanctioned,
+        visibilityStatus: formInitialValues.visibilityStatus,
+        memo: formInitialValues.memo,
         examReviewName: formInitialValues.examReviewName,
         uploadTime: formInitialValues.uploadTime,
         lectureName: formInitialValues.lectureName,
@@ -495,7 +523,7 @@ export function ExamDetailSection({
           <Tabs
             value={activeTab}
             onValueChange={(value) =>
-              setActiveTab(value as 'review' | 'post' | 'comments')
+              setActiveTab(value as 'review' | 'post' | 'comments' | 'logs')
             }
             className='w-full p-4'
           >
@@ -510,6 +538,9 @@ export function ExamDetailSection({
                   </Tabs.Trigger>
                   <Tabs.Trigger value='comments' className='w-fit'>
                     댓글 목록 ({selectedExamReviewDetail?.commentCount ?? 0})
+                  </Tabs.Trigger>
+                  <Tabs.Trigger value='logs' className='w-fit'>
+                    관리 이력 ({selectedExamReviewDetail?.logs?.length ?? 0})
                   </Tabs.Trigger>
                 </Tabs.List>
                 <div className='flex items-center gap-2'>
@@ -595,6 +626,16 @@ export function ExamDetailSection({
                 <Card>
                   <Card.Content className='p-4'>
                     <ExamReviewCommentSection postId={formData.postId} />
+                  </Card.Content>
+                </Card>
+              </Tabs.Content>
+
+              <Tabs.Content value='logs' className='min-h-[460px]'>
+                <Card>
+                  <Card.Content className='p-4'>
+                    <ExamReviewLogSection
+                      logs={selectedExamReviewDetail?.logs}
+                    />
                   </Card.Content>
                 </Card>
               </Tabs.Content>

--- a/src/domains/Reviews/components/ExamMultiSelect.tsx
+++ b/src/domains/Reviews/components/ExamMultiSelect.tsx
@@ -66,12 +66,12 @@ export const ExamMultiSelect = ({
           side={side}
           align={align}
           sideOffset={4}
-          className={`text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-[200px] min-w-[8rem] origin-[var(--radix-select-content-transform-origin)] overflow-x-hidden overflow-y-auto rounded-md border bg-blue-50 shadow-md ${contentClassName}`}
+          className={`bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-[200px] min-w-[8rem] origin-[var(--radix-select-content-transform-origin)] overflow-x-hidden overflow-y-auto rounded-md border shadow-md ${contentClassName}`}
         >
           <div className='p-1'>
             {/* 전체 선택/해제 체크박스 */}
             <div
-              className='relative mb-1 flex w-full cursor-default items-center rounded-sm border-b border-gray-200 px-1.5 py-1.5 text-xs outline-none select-none hover:bg-blue-100/50'
+              className='focus:bg-accent focus:text-accent-foreground hover:bg-accent hover:text-accent-foreground relative mb-1 flex w-full cursor-default items-center rounded-sm border-b px-2 py-1.5 text-sm outline-none select-none'
               onClick={handleSelectAll}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
@@ -93,7 +93,7 @@ export const ExamMultiSelect = ({
                 }`}
                 tabIndex={-1}
               />
-              <span className='flex-1 font-medium'>전체 선택</span>
+              <span className='flex-1 text-left font-normal'>전체 선택</span>
             </div>
             {options.map((option) => {
               const isSelected = value.includes(option);
@@ -103,7 +103,7 @@ export const ExamMultiSelect = ({
               return (
                 <div
                   key={option}
-                  className='relative flex w-full cursor-default items-center rounded-sm px-1.5 py-1.5 text-xs outline-none select-none hover:bg-blue-100/50'
+                  className='focus:bg-accent focus:text-accent-foreground hover:bg-accent hover:text-accent-foreground relative flex w-full cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none'
                   onClick={() => handleToggle(option)}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
@@ -126,7 +126,7 @@ export const ExamMultiSelect = ({
                     }`}
                     tabIndex={-1}
                   />
-                  <span className='flex-1'>{option}</span>
+                  <span className='flex-1 text-left'>{option}</span>
                   {showStatusDot && statusOption && (
                     <div className='ml-2 h-2 w-2 shrink-0 rounded-full bg-blue-500' />
                   )}

--- a/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
+++ b/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
@@ -123,13 +123,37 @@ export function ExamReviewDetailInfoSection({
         <Field className='gap-0'>
           <Field.Label>논의 여부</Field.Label>
           <Field.Content>
-            <div className={STATUS_FIELD_CLASS_NAME}>
-              {renderStatusBadge(
-                formData.isDiscussed ? '논의 있음' : '논의 없음',
-                formData.isDiscussed,
-                'border-blue-200 bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300'
-              )}
-            </div>
+            <Select
+              value={formData.isDiscussed ? 'true' : 'false'}
+              onValueChange={(value) =>
+                setFormData({ isDiscussed: value === 'true' })
+              }
+              disabled={isFormDisabled}
+            >
+              <Select.Trigger className='w-full justify-between rounded-md border border-gray-200 bg-white px-3'>
+                {renderStatusBadge(
+                  formData.isDiscussed ? '논의 있음' : '논의 없음',
+                  formData.isDiscussed,
+                  'border-blue-200 bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300'
+                )}
+              </Select.Trigger>
+              <Select.Content>
+                <Select.Item value='true'>
+                  {renderStatusBadge(
+                    '논의 있음',
+                    true,
+                    'border-blue-200 bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300'
+                  )}
+                </Select.Item>
+                <Select.Item value='false'>
+                  {renderStatusBadge(
+                    '논의 없음',
+                    false,
+                    'border-blue-200 bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300'
+                  )}
+                </Select.Item>
+              </Select.Content>
+            </Select>
           </Field.Content>
         </Field>
         <Field className='gap-0'>
@@ -372,9 +396,13 @@ export function ExamReviewDetailInfoSection({
         <Field className='gap-0 md:col-span-2'>
           <Field.Label>메모</Field.Label>
           <Field.Content>
-            <div className='min-h-[72px] rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm whitespace-pre-wrap text-gray-700'>
-              {formData.memo}
-            </div>
+            <Textarea
+              value={formData.memo ?? ''}
+              onChange={(e) => setFormData({ memo: e.target.value })}
+              disabled={isFormDisabled}
+              rows={3}
+              className='min-h-[96px] resize-none'
+            />
           </Field.Content>
         </Field>
       </div>

--- a/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
+++ b/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
@@ -1,27 +1,37 @@
 import { type RefObject } from 'react';
 
-import { Field, Input, Select, Textarea } from '@/shared/components/ui';
+import { Badge, Field, Input, Select, Textarea } from '@/shared/components/ui';
 import {
+  EXAM_REVIEW_PROCESS_STATUS,
   EXAM_TYPE_LIST,
   LECTURE_TYPE_OPTIONS,
   SEMESTER_LIST,
 } from '@/shared/constants';
+import { cn } from '@/shared/lib';
 
 import { ExamConfirmStatusBadge } from '@/domains/Reviews/components';
-import type { LectureType } from '@/domains/Reviews/types';
+import type {
+  ExamReviewProcessStatus,
+  LectureType,
+} from '@/domains/Reviews/types';
 import { convertLectureTypeToString } from '@/domains/Reviews/utils';
 
 export interface ExamReviewDetailInfoSectionFormData {
   isConfirmed: boolean;
+  isDiscussed: boolean;
   lectureName: string;
   professorName: string;
-  fileName: string;
-  semester: string;
-  examType: string;
   lectureType: LectureType;
+  semester: string;
   classNumber: number | null;
+  examType: string;
   isPF: string;
   isOnline: string;
+  deletionStatus: ExamReviewProcessStatus | null;
+  isSanctioned: boolean;
+  visibilityStatus: ExamReviewProcessStatus | null;
+  memo: string | null;
+  fileName: string;
   examTypeAndQuestions: string;
 }
 
@@ -35,6 +45,39 @@ export interface ExamReviewDetailInfoSectionProps {
   setSelectedFile: (file: File | null) => void;
 }
 
+const STATUS_FIELD_CLASS_NAME =
+  'flex min-h-9 items-center rounded-md border border-gray-200 bg-gray-50 px-3';
+
+const getProcessStatusLabel = (
+  status: ExamReviewProcessStatus | null
+): string => {
+  if (!status) {
+    return '-';
+  }
+
+  return (
+    EXAM_REVIEW_PROCESS_STATUS.find((option) => option.code === status)
+      ?.label ?? status
+  );
+};
+
+const renderStatusBadge = (
+  label: string,
+  isActive: boolean,
+  activeClassName: string
+) => (
+  <Badge
+    variant='outline'
+    className={cn(
+      'max-w-full truncate',
+      isActive ? activeClassName : 'text-gray-500 dark:text-gray-400'
+    )}
+    title={label}
+  >
+    {label}
+  </Badge>
+);
+
 export function ExamReviewDetailInfoSection({
   formData,
   setFormData,
@@ -45,6 +88,10 @@ export function ExamReviewDetailInfoSection({
   setSelectedFile,
 }: ExamReviewDetailInfoSectionProps) {
   const confirmStatus = formData.isConfirmed ? 'CONFIRMED' : 'UNCONFIRMED';
+  const deletionStatusLabel = getProcessStatusLabel(formData.deletionStatus);
+  const visibilityStatusLabel = getProcessStatusLabel(
+    formData.visibilityStatus
+  );
 
   return (
     <div className='space-y-4'>
@@ -71,6 +118,56 @@ export function ExamReviewDetailInfoSection({
                 </Select.Item>
               </Select.Content>
             </Select>
+          </Field.Content>
+        </Field>
+        <Field className='gap-0'>
+          <Field.Label>논의 여부</Field.Label>
+          <Field.Content>
+            <div className={STATUS_FIELD_CLASS_NAME}>
+              {renderStatusBadge(
+                formData.isDiscussed ? '논의 있음' : '논의 없음',
+                formData.isDiscussed,
+                'border-blue-200 bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300'
+              )}
+            </div>
+          </Field.Content>
+        </Field>
+        <Field className='gap-0'>
+          <Field.Label>삭제 상태</Field.Label>
+          <Field.Content>
+            <div className={STATUS_FIELD_CLASS_NAME}>
+              {renderStatusBadge(
+                deletionStatusLabel,
+                formData.deletionStatus !== null &&
+                  formData.deletionStatus !== 'VISIBLE',
+                'border-red-200 bg-red-50 text-red-700 dark:bg-red-950 dark:text-red-300'
+              )}
+            </div>
+          </Field.Content>
+        </Field>
+        <Field className='gap-0'>
+          <Field.Label>징계 여부</Field.Label>
+          <Field.Content>
+            <div className={STATUS_FIELD_CLASS_NAME}>
+              {renderStatusBadge(
+                formData.isSanctioned ? '징계' : '징계 없음',
+                formData.isSanctioned,
+                'border-rose-200 bg-rose-50 text-rose-700 dark:bg-rose-950 dark:text-rose-300'
+              )}
+            </div>
+          </Field.Content>
+        </Field>
+        <Field className='gap-0'>
+          <Field.Label>공개 상태</Field.Label>
+          <Field.Content>
+            <div className={STATUS_FIELD_CLASS_NAME}>
+              {renderStatusBadge(
+                visibilityStatusLabel,
+                formData.visibilityStatus !== null &&
+                  formData.visibilityStatus !== 'VISIBLE',
+                'border-amber-200 bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-300'
+              )}
+            </div>
           </Field.Content>
         </Field>
         <Field className='gap-0'>
@@ -270,6 +367,14 @@ export function ExamReviewDetailInfoSection({
               rows={3}
               className='min-h-[110px] resize-none'
             />
+          </Field.Content>
+        </Field>
+        <Field className='gap-0 md:col-span-2'>
+          <Field.Label>메모</Field.Label>
+          <Field.Content>
+            <div className='min-h-[72px] rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm whitespace-pre-wrap text-gray-700'>
+              {formData.memo}
+            </div>
           </Field.Content>
         </Field>
       </div>

--- a/src/domains/Reviews/components/ExamReviewLogSection.tsx
+++ b/src/domains/Reviews/components/ExamReviewLogSection.tsx
@@ -1,0 +1,154 @@
+import { Badge, Table } from '@/shared/components/ui';
+import {
+  EXAM_CONFIRM_STATUS,
+  EXAM_REVIEW_PROCESS_STATUS,
+} from '@/shared/constants';
+import { formatDateTimeToMinutes } from '@/shared/utils';
+
+import type { ExamReviewDetailLog } from '@/domains/Reviews/types';
+
+interface ExamReviewLogSectionProps {
+  logs?: ExamReviewDetailLog[] | null;
+}
+
+const CHANGE_FIELD_LABELS: Record<string, string> = {
+  action: '작업',
+  status: '상태',
+  statusModifiedReason: '변경 이유',
+  isConfirmed: '확인여부',
+  isDiscussed: '논의여부',
+  lectureName: '강의명',
+  professor: '교수명',
+  lectureType: '강의종류',
+  lectureYear: '강의연도',
+  semester: '수강학기',
+  classNumber: '분반',
+  examType: '시험종류',
+  isPF: 'P/F',
+  isOnline: '온라인 여부',
+  questionDetail: '시험 유형 및 문항수',
+  deletionStatus: '삭제 상태',
+  isSanctioned: '징계 여부',
+  visibilityStatus: '공개 상태',
+  memo: '메모',
+  fileName: '파일명',
+};
+
+const ACTION_LABELS: Record<string, string> = {
+  CREATED: '생성',
+  UPDATED: '수정',
+  DELETED: '삭제',
+  CONFIRMED: '확인',
+  UNCONFIRMED: '미확인',
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  ...Object.fromEntries(
+    EXAM_CONFIRM_STATUS.map(({ code, label }) => [code, label])
+  ),
+  ...Object.fromEntries(
+    EXAM_REVIEW_PROCESS_STATUS.map(({ code, label }) => [code, label])
+  ),
+};
+
+const formatStatusValue = (value: string): string =>
+  value
+    .split(/\s*->\s*/)
+    .map((status) => STATUS_LABELS[status] ?? status)
+    .join(' -> ');
+
+const formatChangeValue = (
+  key: string,
+  value: string | number | boolean | null,
+  statusModifiedReason?: string | number | boolean | null
+): string => {
+  if (value === null) {
+    return '-';
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+
+  if (key === 'action') {
+    const actionValue = String(value);
+    return ACTION_LABELS[actionValue] ?? actionValue;
+  }
+
+  if (key === 'status') {
+    const formattedStatus = formatStatusValue(String(value));
+    return statusModifiedReason
+      ? `${formattedStatus} (${String(statusModifiedReason)})`
+      : formattedStatus;
+  }
+
+  return String(value);
+};
+
+const getVisibleChanges = (changes?: ExamReviewDetailLog['changes'] | null) =>
+  Object.entries(changes ?? {}).filter(
+    ([key]) => key !== 'statusModifiedReason'
+  );
+
+export function ExamReviewLogSection({ logs }: ExamReviewLogSectionProps) {
+  const safeLogs = logs ?? [];
+
+  if (safeLogs.length === 0) {
+    return (
+      <div className='flex min-h-[240px] items-center justify-center rounded-md border border-gray-200 bg-gray-50 text-sm text-gray-500'>
+        관리 이력이 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className='overflow-hidden rounded-md border border-gray-200'>
+      <Table className='table-fixed bg-white'>
+        <colgroup>
+          <col className='w-[150px]' />
+          <col className='w-[120px]' />
+          <col className='w-full' />
+        </colgroup>
+        <Table.Header className='bg-gray-100'>
+          <Table.Row>
+            <Table.Head>변경일시</Table.Head>
+            <Table.Head>관리자</Table.Head>
+            <Table.Head className='w-full'>변경 내용</Table.Head>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {safeLogs.map((log, index) => (
+            <Table.Row key={`${log.createdAt}-${index}`}>
+              <Table.Cell>{formatDateTimeToMinutes(log.createdAt)}</Table.Cell>
+              <Table.Cell>{log.adminName || '-'}</Table.Cell>
+              <Table.Cell className='whitespace-normal'>
+                <div className='flex flex-col gap-1.5'>
+                  {getVisibleChanges(log.changes).map(([key, value]) => (
+                    <div
+                      key={key}
+                      className='flex flex-wrap items-center gap-2'
+                    >
+                      <Badge
+                        variant='outline'
+                        className='bg-gray-50 text-gray-700'
+                      >
+                        {CHANGE_FIELD_LABELS[key] ?? key}
+                      </Badge>
+                      <span className='text-sm break-all text-gray-700'>
+                        {formatChangeValue(
+                          key,
+                          value,
+                          log.changes?.statusModifiedReason
+                        )}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+    </div>
+  );
+}

--- a/src/domains/Reviews/components/ExamSearch.tsx
+++ b/src/domains/Reviews/components/ExamSearch.tsx
@@ -1,12 +1,15 @@
 import { useState } from 'react';
 
-import { X } from 'lucide-react';
+import { ChevronDown, X } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Button, Input, Select } from '@/shared/components/ui';
-import { EXAM_TYPE_LIST, SEMESTER_LIST } from '@/shared/constants';
+import {
+  EXAM_REVIEW_PROCESS_STATUS,
+  EXAM_TYPE_LIST,
+  SEMESTER_LIST,
+} from '@/shared/constants';
 
-import { ExamConfirmStatusBadge } from '@/domains/Reviews/components';
 import {
   type ExamReviewSearchParams,
   isExamReviewSort,
@@ -16,6 +19,9 @@ import {
   convertSemesterToEnum,
   extractYearFromSemester,
 } from '@/domains/Reviews/utils';
+
+import { ExamConfirmStatusBadge } from './ExamConfirmStatusBadge';
+import { ExamMultiSelect } from './ExamMultiSelect';
 
 interface ExamSearchProps {
   onSearchChange: (params: ExamReviewSearchParams) => void;
@@ -27,7 +33,59 @@ interface ExamSearchProps {
   initialSemester?: string;
   initialExamType?: string;
   initialIsConfirmed?: boolean;
+  initialIsDiscussed?: boolean;
+  initialIsReported?: boolean;
+  initialStatuses?: string;
 }
+
+const ALL_SELECTED = '전체';
+const TRUE_SELECTED = 'TRUE';
+const FALSE_SELECTED = 'FALSE';
+const CONFIRMED_SELECTED = 'CONFIRMED';
+const UNCONFIRMED_SELECTED = 'UNCONFIRMED';
+const PROCESS_STATUS_OPTIONS: string[] = EXAM_REVIEW_PROCESS_STATUS.map(
+  (status) => status.label
+);
+
+const isDefined = <T,>(value: T | undefined): value is T => value !== undefined;
+
+const getBooleanFilterValue = (value?: boolean): string => {
+  if (value === true) {
+    return TRUE_SELECTED;
+  }
+
+  if (value === false) {
+    return FALSE_SELECTED;
+  }
+
+  return ALL_SELECTED;
+};
+
+const getStatusLabelsFromCodes = (statuses?: string): string[] => {
+  if (!statuses) {
+    return [];
+  }
+
+  return statuses
+    .split(',')
+    .map((status) => status.trim())
+    .map((statusCode) => {
+      return EXAM_REVIEW_PROCESS_STATUS.find(
+        (status) => status.code === statusCode
+      )?.label;
+    })
+    .filter(isDefined);
+};
+
+const getStatusCodesFromLabels = (statusLabels: string[]): string =>
+  statusLabels
+    .map((statusLabel) => {
+      return EXAM_REVIEW_PROCESS_STATUS.find(
+        (status) => status.label === statusLabel
+      )?.code;
+    })
+    .filter(isDefined)
+    .join(',');
 
 export default function ExamSearch({
   onSearchChange,
@@ -39,13 +97,12 @@ export default function ExamSearch({
   initialSemester,
   initialExamType,
   initialIsConfirmed,
+  initialIsDiscussed,
+  initialIsReported,
+  initialStatuses,
 }: ExamSearchProps) {
-  const ALL_SELECTED = '전체';
-  const CONFIRMED_SELECTED = 'CONFIRMED';
-  const UNCONFIRMED_SELECTED = 'UNCONFIRMED';
-
   // key prop을 사용하여 prop 변경 시 컴포넌트 재초기화 (useEffect 대신)
-  const searchKey = `${initialStartDate}-${initialEndDate}-${initialKeywordAuthor}-${initialKeywordPost}-${initialSort}-${initialSemester}-${initialExamType}-${initialIsConfirmed}`;
+  const searchKey = `${initialStartDate}-${initialEndDate}-${initialKeywordAuthor}-${initialKeywordPost}-${initialSort}-${initialSemester}-${initialExamType}-${initialIsConfirmed}-${initialIsDiscussed}-${initialIsReported}-${initialStatuses}`;
 
   // 내부 상태는 사용자 입력용으로만 사용
   const [startDate, setStartDate] = useState<string>(initialStartDate);
@@ -69,6 +126,15 @@ export default function ExamSearch({
         ? UNCONFIRMED_SELECTED
         : ALL_SELECTED
   );
+  const [discussionStatus, setDiscussionStatus] = useState<string>(
+    getBooleanFilterValue(initialIsDiscussed)
+  );
+  const [reportStatus, setReportStatus] = useState<string>(
+    getBooleanFilterValue(initialIsReported)
+  );
+  const [selectedStatuses, setSelectedStatuses] = useState<string[]>(
+    getStatusLabelsFromCodes(initialStatuses)
+  );
 
   // 검색 실행 함수 (현재 상태 기반)
   const handleSearch = () => {
@@ -87,6 +153,9 @@ export default function ExamSearch({
         semester,
         examType,
         confirmStatus,
+        discussionStatus,
+        reportStatus,
+        selectedStatuses,
       })
     );
   };
@@ -100,6 +169,9 @@ export default function ExamSearch({
     semester: targetSemester,
     examType: targetExamType,
     confirmStatus: targetConfirmStatus,
+    discussionStatus: targetDiscussionStatus,
+    reportStatus: targetReportStatus,
+    selectedStatuses: targetSelectedStatuses,
   }: {
     startDate: string;
     endDate: string;
@@ -109,6 +181,9 @@ export default function ExamSearch({
     semester: string;
     examType: string;
     confirmStatus: string;
+    discussionStatus: string;
+    reportStatus: string;
+    selectedStatuses: string[];
   }) => {
     const params: ExamReviewSearchParams = {};
 
@@ -152,6 +227,27 @@ export default function ExamSearch({
       params.isConfirmed = false;
     }
 
+    if (targetDiscussionStatus === TRUE_SELECTED) {
+      params.isDiscussed = true;
+    }
+
+    if (targetDiscussionStatus === FALSE_SELECTED) {
+      params.isDiscussed = false;
+    }
+
+    if (targetReportStatus === TRUE_SELECTED) {
+      params.isReported = true;
+    }
+
+    if (targetReportStatus === FALSE_SELECTED) {
+      params.isReported = false;
+    }
+
+    const statuses = getStatusCodesFromLabels(targetSelectedStatuses);
+    if (statuses) {
+      params.statuses = statuses;
+    }
+
     return params;
   };
 
@@ -165,6 +261,9 @@ export default function ExamSearch({
       semester: string;
       examType: string;
       confirmStatus: string;
+      discussionStatus: string;
+      reportStatus: string;
+      selectedStatuses: string[];
     }>
   ) => {
     onSearchChange(
@@ -177,6 +276,9 @@ export default function ExamSearch({
         semester,
         examType,
         confirmStatus,
+        discussionStatus,
+        reportStatus,
+        selectedStatuses,
         ...nextParams,
       })
     );
@@ -210,6 +312,9 @@ export default function ExamSearch({
     setSemester(ALL_SELECTED);
     setExamType(ALL_SELECTED);
     setConfirmStatus(ALL_SELECTED);
+    setDiscussionStatus(ALL_SELECTED);
+    setReportStatus(ALL_SELECTED);
+    setSelectedStatuses([]);
     onSearchChange({});
   };
 
@@ -301,9 +406,6 @@ export default function ExamSearch({
             <Select.Item value='DESC' className='text-sm'>
               제목 내림차순
             </Select.Item>
-            <Select.Item value='REPORT' className='text-sm'>
-              신고순
-            </Select.Item>
           </Select.Content>
         </Select>
 
@@ -387,6 +489,75 @@ export default function ExamSearch({
             </Select.Item>
           </Select.Content>
         </Select>
+
+        <Select
+          value={discussionStatus}
+          onValueChange={(value) => {
+            setDiscussionStatus(value);
+            handleSearchWithParams({ discussionStatus: value });
+          }}
+        >
+          <Select.Trigger className='h-9 w-[150px] text-sm'>
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Content align='start'>
+            <Select.Item value={ALL_SELECTED} className='text-sm'>
+              논의 여부 전체
+            </Select.Item>
+            <Select.Item value={TRUE_SELECTED} className='text-sm'>
+              논의 있음
+            </Select.Item>
+            <Select.Item value={FALSE_SELECTED} className='text-sm'>
+              논의 없음
+            </Select.Item>
+          </Select.Content>
+        </Select>
+
+        <Select
+          value={reportStatus}
+          onValueChange={(value) => {
+            setReportStatus(value);
+            handleSearchWithParams({ reportStatus: value });
+          }}
+        >
+          <Select.Trigger className='h-9 w-[150px] text-sm'>
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Content align='start'>
+            <Select.Item value={ALL_SELECTED} className='text-sm'>
+              신고 여부 전체
+            </Select.Item>
+            <Select.Item value={TRUE_SELECTED} className='text-sm'>
+              신고 있음
+            </Select.Item>
+            <Select.Item value={FALSE_SELECTED} className='text-sm'>
+              신고 없음
+            </Select.Item>
+          </Select.Content>
+        </Select>
+
+        <ExamMultiSelect
+          value={selectedStatuses}
+          onValueChange={(value) => {
+            setSelectedStatuses(value);
+            handleSearchWithParams({ selectedStatuses: value });
+          }}
+          options={PROCESS_STATUS_OPTIONS}
+          contentClassName='w-[190px]'
+        >
+          <Button
+            type='button'
+            variant='outline'
+            className='border-input h-9 w-[190px] justify-between bg-transparent px-3 text-sm font-normal hover:bg-transparent'
+          >
+            <span className='truncate'>
+              {selectedStatuses.length > 0
+                ? `처리 상태 ${selectedStatuses.length}개`
+                : '처리 상태 전체'}
+            </span>
+            <ChevronDown className='size-4 opacity-50' />
+          </Button>
+        </ExamMultiSelect>
       </div>
     </div>
   );

--- a/src/domains/Reviews/components/ExamTable.tsx
+++ b/src/domains/Reviews/components/ExamTable.tsx
@@ -7,7 +7,8 @@ import {
   useState,
 } from 'react';
 
-import { Table } from '@/shared/components/ui';
+import { Badge, Table } from '@/shared/components/ui';
+import { EXAM_REVIEW_PROCESS_STATUS } from '@/shared/constants';
 import { cn } from '@/shared/lib';
 
 import {
@@ -20,6 +21,7 @@ import {
 import { useExamReviews } from '@/domains/Reviews/hooks';
 import type {
   ExamReview,
+  ExamReviewProcessStatus,
   ExamReviewSearchParams,
 } from '@/domains/Reviews/types';
 
@@ -33,6 +35,83 @@ interface ExamReviewTableColumn {
   render?: (review: ExamReview) => ReactNode;
 }
 
+const PROCESS_STATUS_BADGE_CLASS_NAMES: Record<
+  ExamReviewProcessStatus,
+  string
+> = {
+  VISIBLE: 'bg-gray-100 text-gray-700 dark:bg-gray-900 dark:text-gray-300',
+  USER_DELETED:
+    'bg-slate-100 text-slate-700 dark:bg-slate-900 dark:text-slate-300',
+  ADMIN_DELETED: 'bg-red-50 text-red-700 dark:bg-red-950 dark:text-red-300',
+  ADMIN_HIDDEN:
+    'bg-orange-50 text-orange-700 dark:bg-orange-950 dark:text-orange-300',
+  AUTO_HIDDEN:
+    'bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-300',
+  SANCTIONED: 'bg-rose-50 text-rose-700 dark:bg-rose-950 dark:text-rose-300',
+  DESANCTIONED:
+    'bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300',
+};
+
+const getProcessStatusLabel = (status: ExamReviewProcessStatus): string =>
+  EXAM_REVIEW_PROCESS_STATUS.find((option) => option.code === status)?.label ??
+  status;
+
+const renderBooleanBadge = (
+  value: boolean,
+  trueLabel: string,
+  falseLabel: string
+) => (
+  <Badge
+    variant='outline'
+    className={cn(
+      'max-w-full truncate',
+      value
+        ? 'border-blue-200 bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300'
+        : 'text-gray-500 dark:text-gray-400'
+    )}
+    title={value ? trueLabel : falseLabel}
+  >
+    {value ? trueLabel : falseLabel}
+  </Badge>
+);
+
+const renderReportBadge = (review: ExamReview) => {
+  const label = review.isReported ? `신고 ${review.reportCount}` : '신고 없음';
+
+  return (
+    <Badge
+      variant='outline'
+      className={cn(
+        'max-w-full truncate',
+        review.isReported
+          ? 'border-red-200 bg-red-50 text-red-700 dark:bg-red-950 dark:text-red-300'
+          : 'text-gray-500 dark:text-gray-400'
+      )}
+      title={label}
+    >
+      {label}
+    </Badge>
+  );
+};
+
+const renderProcessStatusBadge = (review: ExamReview) => {
+  const label = review.processStatuses.map(getProcessStatusLabel).join(', ');
+
+  return (
+    <div className='flex flex-wrap gap-1' title={label}>
+      {review.processStatuses.map((status) => (
+        <Badge
+          key={status}
+          variant='outline'
+          className={PROCESS_STATUS_BADGE_CLASS_NAMES[status]}
+        >
+          {getProcessStatusLabel(status)}
+        </Badge>
+      ))}
+    </div>
+  );
+};
+
 const EXAM_REVIEW_TABLE_COLUMNS: ExamReviewTableColumn[] = [
   {
     key: 'status',
@@ -43,8 +122,27 @@ const EXAM_REVIEW_TABLE_COLUMNS: ExamReviewTableColumn[] = [
     ),
   },
   { key: 'id', label: 'postId', width: '90px' },
-  { key: 'reviewTitle', label: '시험후기명' },
+  { key: 'reviewTitle', label: '시험후기명', width: '320px' },
   { key: 'userDisplay', label: '작성자', width: '120px' },
+  {
+    key: 'isDiscussed',
+    label: '논의 여부',
+    width: '92px',
+    render: (review: ExamReview) =>
+      renderBooleanBadge(review.isDiscussed, '논의 있음', '논의 없음'),
+  },
+  {
+    key: 'isReported',
+    label: '신고 여부',
+    width: '92px',
+    render: renderReportBadge,
+  },
+  {
+    key: 'processStatuses',
+    label: '처리상태',
+    width: '92px',
+    render: renderProcessStatusBadge,
+  },
   { key: 'uploadTime', label: '작성일', width: '150px' },
 ];
 
@@ -94,6 +192,9 @@ export default function ExamTable({
     semester: searchParams.semester,
     examType: searchParams.examType,
     isConfirmed: searchParams.isConfirmed,
+    isDiscussed: searchParams.isDiscussed,
+    isReported: searchParams.isReported,
+    statuses: searchParams.statuses,
     enabled: !propData,
     refreshKey, // refreshKey를 queryKey에 포함시켜 자동 refetch
   });
@@ -104,6 +205,7 @@ export default function ExamTable({
   );
   const hasNext = queryData?.hasNext ?? false;
   const totalPage = queryData?.totalPage;
+  const columnCount = EXAM_REVIEW_TABLE_COLUMNS.length;
 
   // 선택된 행이 있으면 업데이트된 데이터로 자동 선택
   useEffect(() => {
@@ -126,7 +228,7 @@ export default function ExamTable({
 
   return (
     <>
-      <div className='w-full overflow-hidden rounded-md border'>
+      <div className='w-full overflow-x-auto rounded-md border'>
         <Table className='w-full table-fixed rounded-lg bg-white shadow'>
           <colgroup>
             {EXAM_REVIEW_TABLE_COLUMNS.map((column) => (
@@ -149,9 +251,12 @@ export default function ExamTable({
 
           <Table.Body>
             {isLoading ? (
-              <ExamTableSkeleton itemsPerPage={ITEMS_PER_PAGE} />
+              <ExamTableSkeleton
+                itemsPerPage={ITEMS_PER_PAGE}
+                columnCount={columnCount}
+              />
             ) : currentPageData.length === 0 ? (
-              <ExamTableEmpty />
+              <ExamTableEmpty columnCount={columnCount} />
             ) : (
               <>
                 {currentPageData.map((review: ExamReview) => {
@@ -175,7 +280,11 @@ export default function ExamTable({
                       {EXAM_REVIEW_TABLE_COLUMNS.map((column) => (
                         <Table.Cell
                           key={column.key}
-                          className='overflow-hidden text-ellipsis whitespace-nowrap'
+                          className={cn(
+                            'overflow-hidden text-ellipsis whitespace-nowrap',
+                            column.key === 'processStatuses' &&
+                              'whitespace-normal'
+                          )}
                         >
                           {column.render
                             ? column.render(review)
@@ -189,6 +298,7 @@ export default function ExamTable({
                 })}
                 <ExamTableEmptyRows
                   count={ITEMS_PER_PAGE - currentPageData.length}
+                  columnCount={columnCount}
                 />
               </>
             )}

--- a/src/domains/Reviews/components/ExamTableFallback.tsx
+++ b/src/domains/Reviews/components/ExamTableFallback.tsx
@@ -1,47 +1,48 @@
 import { Skeleton, Table } from '@/shared/components/ui';
 
+const DEFAULT_EXAM_TABLE_COLUMN_COUNT = 8;
+
 // ======= types =======
 interface ExamTableSkeletonProps {
   itemsPerPage?: number;
+  columnCount?: number;
 }
 
 interface ExamTableEmptyRowsProps {
   count: number;
+  columnCount?: number;
+}
+
+interface ExamTableEmptyProps {
+  columnCount?: number;
 }
 
 // ======= components =======
 export function ExamTableSkeleton({
   itemsPerPage = 10,
+  columnCount = DEFAULT_EXAM_TABLE_COLUMN_COUNT,
 }: ExamTableSkeletonProps) {
   return (
     <>
       {Array.from({ length: itemsPerPage }).map((_, index) => (
         <Table.Row key={`skeleton-${index}`} className='[&_td]:h-[40px]'>
-          <Table.Cell>
-            <Skeleton className='h-4 w-full' />
-          </Table.Cell>
-          <Table.Cell>
-            <Skeleton className='h-4 w-full' />
-          </Table.Cell>
-          <Table.Cell>
-            <Skeleton className='h-4 w-full' />
-          </Table.Cell>
-          <Table.Cell>
-            <Skeleton className='h-4 w-full' />
-          </Table.Cell>
-          <Table.Cell>
-            <Skeleton className='h-4 w-full' />
-          </Table.Cell>
+          {Array.from({ length: columnCount }).map((_, cellIndex) => (
+            <Table.Cell key={`skeleton-${index}-${cellIndex}`}>
+              <Skeleton className='h-4 w-full' />
+            </Table.Cell>
+          ))}
         </Table.Row>
       ))}
     </>
   );
 }
 
-export function ExamTableEmpty() {
+export function ExamTableEmpty({
+  columnCount = DEFAULT_EXAM_TABLE_COLUMN_COUNT,
+}: ExamTableEmptyProps) {
   return (
     <Table.Row>
-      <Table.Cell colSpan={5} className='h-[240px] p-0 text-gray-500'>
+      <Table.Cell colSpan={columnCount} className='h-[240px] p-0 text-gray-500'>
         <div className='flex h-full items-center justify-center'>
           해당하는 데이터가 없습니다
         </div>
@@ -50,18 +51,19 @@ export function ExamTableEmpty() {
   );
 }
 
-export function ExamTableEmptyRows({ count }: ExamTableEmptyRowsProps) {
+export function ExamTableEmptyRows({
+  count,
+  columnCount = DEFAULT_EXAM_TABLE_COLUMN_COUNT,
+}: ExamTableEmptyRowsProps) {
   if (count <= 0) return null;
 
   return (
     <>
       {Array.from({ length: count }).map((_, index) => (
         <Table.Row key={`empty-${index}`} className='[&_td]:h-[24px]'>
-          <Table.Cell>&nbsp;</Table.Cell>
-          <Table.Cell>&nbsp;</Table.Cell>
-          <Table.Cell>&nbsp;</Table.Cell>
-          <Table.Cell>&nbsp;</Table.Cell>
-          <Table.Cell>&nbsp;</Table.Cell>
+          {Array.from({ length: columnCount }).map((_, cellIndex) => (
+            <Table.Cell key={`empty-${index}-${cellIndex}`}>&nbsp;</Table.Cell>
+          ))}
         </Table.Row>
       ))}
     </>

--- a/src/domains/Reviews/components/index.ts
+++ b/src/domains/Reviews/components/index.ts
@@ -6,6 +6,7 @@ export { default as ExamDiscussionPanel } from './ExamDiscussionPanel';
 export { ExamMultiSelect } from './ExamMultiSelect';
 export { ExamReviewCommentSection } from './ExamReviewCommentSection';
 export { ExamReviewDetailInfoSection } from './ExamReviewDetailInfoSection';
+export { ExamReviewLogSection } from './ExamReviewLogSection';
 export { ExamReviewPeriodDeleteConfirmModal } from './ExamReviewPeriodDeleteConfirmModal';
 export { ExamReviewPeriodListSection } from './ExamReviewPeriodListSection';
 export { ExamReviewPeriodScheduleForm } from './ExamReviewPeriodScheduleForm';

--- a/src/domains/Reviews/hooks/use-exam-reviews.ts
+++ b/src/domains/Reviews/hooks/use-exam-reviews.ts
@@ -5,13 +5,13 @@ import { formatDateTimeToMinutes } from '@/shared/utils';
 import { STATUS } from '@/domains/Reviews/constants';
 import type {
   ExamReview,
-  ExamReviewProcessStatus,
   ExamReviewSearchParams,
   ExamReviews,
 } from '@/domains/Reviews/types';
 import {
   convertExamTypeEnumToString,
   convertSemesterEnumToString,
+  getExamReviewProcessStatuses,
 } from '@/domains/Reviews/utils';
 
 import { getExamReviews } from '@/apis';
@@ -21,29 +21,6 @@ interface UseExamReviewsParams extends ExamReviewSearchParams {
   enabled?: boolean;
   refreshKey?: number;
 }
-
-const isSanctioned = (value: ExamReviews['isSanctioned']): boolean =>
-  value === true || value === 'true';
-
-const getProcessStatuses = (
-  apiData: ExamReviews
-): ExamReviewProcessStatus[] => {
-  const processStatuses: ExamReviewProcessStatus[] = [];
-
-  if (apiData.deletionStatus && apiData.deletionStatus !== 'VISIBLE') {
-    processStatuses.push(apiData.deletionStatus);
-  }
-
-  if (apiData.visibilityStatus && apiData.visibilityStatus !== 'VISIBLE') {
-    processStatuses.push(apiData.visibilityStatus);
-  }
-
-  if (isSanctioned(apiData.isSanctioned)) {
-    processStatuses.push('SANCTIONED');
-  }
-
-  return processStatuses.length > 0 ? processStatuses : ['VISIBLE'];
-};
 
 const transformApiResponseToExamReview = (apiData: ExamReviews): ExamReview => {
   const reviewTitle = apiData.title || apiData.content || '';
@@ -85,7 +62,7 @@ const transformApiResponseToExamReview = (apiData: ExamReviews): ExamReview => {
     isDiscussed: apiData.isDiscussed ?? false,
     isReported: reportCount > 0,
     reportCount,
-    processStatuses: getProcessStatuses(apiData),
+    processStatuses: getExamReviewProcessStatuses(apiData),
   };
 };
 

--- a/src/domains/Reviews/hooks/use-exam-reviews.ts
+++ b/src/domains/Reviews/hooks/use-exam-reviews.ts
@@ -5,6 +5,7 @@ import { formatDateTimeToMinutes } from '@/shared/utils';
 import { STATUS } from '@/domains/Reviews/constants';
 import type {
   ExamReview,
+  ExamReviewProcessStatus,
   ExamReviewSearchParams,
   ExamReviews,
 } from '@/domains/Reviews/types';
@@ -20,6 +21,29 @@ interface UseExamReviewsParams extends ExamReviewSearchParams {
   enabled?: boolean;
   refreshKey?: number;
 }
+
+const isSanctioned = (value: ExamReviews['isSanctioned']): boolean =>
+  value === true || value === 'true';
+
+const getProcessStatuses = (
+  apiData: ExamReviews
+): ExamReviewProcessStatus[] => {
+  const processStatuses: ExamReviewProcessStatus[] = [];
+
+  if (apiData.deletionStatus && apiData.deletionStatus !== 'VISIBLE') {
+    processStatuses.push(apiData.deletionStatus);
+  }
+
+  if (apiData.visibilityStatus && apiData.visibilityStatus !== 'VISIBLE') {
+    processStatuses.push(apiData.visibilityStatus);
+  }
+
+  if (isSanctioned(apiData.isSanctioned)) {
+    processStatuses.push('SANCTIONED');
+  }
+
+  return processStatuses.length > 0 ? processStatuses : ['VISIBLE'];
+};
 
 const transformApiResponseToExamReview = (apiData: ExamReviews): ExamReview => {
   const reviewTitle = apiData.title || apiData.content || '';
@@ -44,6 +68,7 @@ const transformApiResponseToExamReview = (apiData: ExamReviews): ExamReview => {
         ? STATUS.UNCONFIRMED
         : apiData.status || STATUS.UNCONFIRMED;
   const userDisplay = apiData.userName || apiData.userDisplay || '';
+  const reportCount = apiData.reportCount ?? 0;
 
   return {
     id: apiData.postId,
@@ -57,6 +82,10 @@ const transformApiResponseToExamReview = (apiData: ExamReviews): ExamReview => {
     questionDetail: '',
     uploadTime,
     userDisplay,
+    isDiscussed: apiData.isDiscussed ?? false,
+    isReported: reportCount > 0,
+    reportCount,
+    processStatuses: getProcessStatuses(apiData),
   };
 };
 
@@ -72,6 +101,9 @@ export const useExamReviews = (params: UseExamReviewsParams) => {
     semester,
     examType,
     isConfirmed,
+    isDiscussed,
+    isReported,
+    statuses,
     enabled = true,
     refreshKey,
   } = params;
@@ -89,6 +121,9 @@ export const useExamReviews = (params: UseExamReviewsParams) => {
       semester,
       examType,
       isConfirmed,
+      isDiscussed,
+      isReported,
+      statuses,
       refreshKey,
     ],
     queryFn: async () => {
@@ -103,6 +138,9 @@ export const useExamReviews = (params: UseExamReviewsParams) => {
         semester,
         examType,
         isConfirmed,
+        isDiscussed,
+        isReported,
+        statuses,
       });
 
       if (!response.isSuccess || !response.result) {

--- a/src/domains/Reviews/types/exam.ts
+++ b/src/domains/Reviews/types/exam.ts
@@ -14,9 +14,18 @@ export type ExamType = (typeof EXAM_TYPE)[keyof typeof EXAM_TYPE];
 
 export type Status = (typeof STATUS)[keyof typeof STATUS];
 
-export const EXAM_REVIEW_SORTS = ['ASC', 'DESC', 'REPORT'] as const;
+export const EXAM_REVIEW_SORTS = ['ASC', 'DESC'] as const;
 
 export type ExamReviewSort = (typeof EXAM_REVIEW_SORTS)[number];
+
+export type ExamReviewProcessStatus =
+  | 'VISIBLE'
+  | 'USER_DELETED'
+  | 'ADMIN_DELETED'
+  | 'ADMIN_HIDDEN'
+  | 'AUTO_HIDDEN'
+  | 'SANCTIONED'
+  | 'DESANCTIONED';
 
 export const isExamReviewSort = (
   value?: string | null
@@ -33,6 +42,9 @@ export interface ExamReviewSearchParams {
   semester?: string;
   examType?: string;
   isConfirmed?: boolean;
+  isDiscussed?: boolean;
+  isReported?: boolean;
+  statuses?: string;
 }
 
 export interface ExamReview {
@@ -47,6 +59,10 @@ export interface ExamReview {
   questionDetail: string;
   uploadTime: string;
   userDisplay: string;
+  isDiscussed: boolean;
+  isReported: boolean;
+  reportCount: number;
+  processStatuses: ExamReviewProcessStatus[];
 }
 
 export interface ExamReviews {
@@ -60,6 +76,11 @@ export interface ExamReviews {
   encryptedUserId: string | null;
   userDisplay?: string | null;
   userName: string | null;
+  reportCount?: number;
+  isDiscussed?: boolean;
+  deletionStatus?: ExamReviewProcessStatus | null;
+  isSanctioned?: boolean | 'true' | 'false' | null;
+  visibilityStatus?: ExamReviewProcessStatus | null;
   lectureYear?: number;
   lectureSemester?: Semester;
   examType?: ExamType;

--- a/src/domains/Reviews/types/exam.ts
+++ b/src/domains/Reviews/types/exam.ts
@@ -141,20 +141,21 @@ export interface DeleteExamReviewResponse {
   };
 }
 
+export interface ExamReviewDetailLog {
+  encryptedAdminId: string | null;
+  adminName: string | null;
+  changes?: Record<string, string | number | boolean | null> | null;
+  createdAt: string;
+}
+
 export interface ExamReviewDetailResult {
   encryptedUserId: string;
   userDisplay: string;
-  isWriter: boolean;
-  isWriterWithdrawn: boolean;
   postId: number;
-  title: string;
+  title?: string;
   commentCount: number;
-  scrapCount: number;
-  isScrapped: boolean;
   status?: string;
   createdAt: string;
-  isNotice: boolean;
-  isEdited: boolean;
   lectureName: string;
   professor: string;
   classNumber: number;
@@ -165,9 +166,14 @@ export interface ExamReviewDetailResult {
   isOnline: boolean;
   examType: ExamType;
   isConfirmed: boolean;
+  isDiscussed: boolean;
+  deletionStatus: ExamReviewProcessStatus | null;
+  isSanctioned: boolean | 'true' | 'false' | null;
+  visibilityStatus: ExamReviewProcessStatus | null;
+  memo: string | null;
   fileName: string;
   questionDetail: string;
-  isDownloaded: boolean;
+  logs: ExamReviewDetailLog[] | null;
 }
 
 export interface ExamReviewDetailResponse {

--- a/src/domains/Reviews/types/exam.ts
+++ b/src/domains/Reviews/types/exam.ts
@@ -105,6 +105,8 @@ export interface ConfirmExamReviewResponse {
 }
 
 export interface UpdateExamReviewPost {
+  isConfirmed?: boolean;
+  isDiscussed?: boolean;
   lectureName?: string;
   professor?: string;
   classNumber?: number;
@@ -116,6 +118,7 @@ export interface UpdateExamReviewPost {
   status?: string;
   examType?: ExamType;
   questionDetail?: string;
+  memo?: string | null;
 }
 
 export interface UpdateExamReviewRequest {
@@ -127,9 +130,7 @@ export interface UpdateExamReviewResponse {
   isSuccess: boolean;
   code: number;
   message: string;
-  result: {
-    postId: number;
-  };
+  result: ExamReviewDetailResult;
 }
 
 export interface DeleteExamReviewResponse {

--- a/src/domains/Reviews/types/index.ts
+++ b/src/domains/Reviews/types/index.ts
@@ -3,6 +3,7 @@ export type {
   ConfirmExamReviewResponse,
   DeleteExamReviewResponse,
   ExamReview,
+  ExamReviewDetailLog,
   ExamReviewDetailResponse,
   ExamReviewDetailResult,
   ExamReviewProcessStatus,

--- a/src/domains/Reviews/types/index.ts
+++ b/src/domains/Reviews/types/index.ts
@@ -5,6 +5,7 @@ export type {
   ExamReview,
   ExamReviewDetailResponse,
   ExamReviewDetailResult,
+  ExamReviewProcessStatus,
   ExamReviews,
   ExamReviewSearchParams,
   ExamReviewSort,

--- a/src/domains/Reviews/utils/exam-formatters.ts
+++ b/src/domains/Reviews/utils/exam-formatters.ts
@@ -1,5 +1,37 @@
 import { EXAM_CONFIRM_STATUS } from '@/shared/constants';
 
+import type { ExamReviewProcessStatus } from '@/domains/Reviews/types';
+
+interface ExamReviewProcessStatusSource {
+  deletionStatus?: ExamReviewProcessStatus | null;
+  visibilityStatus?: ExamReviewProcessStatus | null;
+  isSanctioned?: boolean | 'true' | 'false' | null;
+}
+
+export const isExamReviewSanctioned = (
+  value: ExamReviewProcessStatusSource['isSanctioned']
+): boolean => value === true || value === 'true';
+
+export const getExamReviewProcessStatuses = (
+  source: ExamReviewProcessStatusSource
+): ExamReviewProcessStatus[] => {
+  const processStatuses: ExamReviewProcessStatus[] = [];
+
+  if (source.deletionStatus && source.deletionStatus !== 'VISIBLE') {
+    processStatuses.push(source.deletionStatus);
+  }
+
+  if (source.visibilityStatus && source.visibilityStatus !== 'VISIBLE') {
+    processStatuses.push(source.visibilityStatus);
+  }
+
+  if (isExamReviewSanctioned(source.isSanctioned)) {
+    processStatuses.push('SANCTIONED');
+  }
+
+  return processStatuses.length > 0 ? processStatuses : ['VISIBLE'];
+};
+
 /**
  * lectureType enum을 문자열로 변환
  * @param lectureTypeEnum - 변환할 lectureType enum 값

--- a/src/domains/Reviews/utils/exam-formatters.ts
+++ b/src/domains/Reviews/utils/exam-formatters.ts
@@ -105,25 +105,17 @@ export const convertExamTypeEnumToString = (
 export const convertSemesterToEnum = (
   semesterStr: string
 ): 'FIRST' | 'SECOND' | 'SUMMER' | 'WINTER' | 'OTHER' => {
-  if (
-    semesterStr.includes('1') &&
-    !semesterStr.includes('여름') &&
-    !semesterStr.includes('겨울')
-  ) {
-    return 'FIRST';
-  }
-  if (
-    semesterStr.includes('2') &&
-    !semesterStr.includes('여름') &&
-    !semesterStr.includes('겨울')
-  ) {
-    return 'SECOND';
-  }
   if (semesterStr.includes('여름')) {
     return 'SUMMER';
   }
   if (semesterStr.includes('겨울')) {
     return 'WINTER';
+  }
+  if (semesterStr.endsWith('-1')) {
+    return 'FIRST';
+  }
+  if (semesterStr.endsWith('-2')) {
+    return 'SECOND';
   }
   return 'OTHER';
 };

--- a/src/domains/Reviews/utils/index.ts
+++ b/src/domains/Reviews/utils/index.ts
@@ -5,5 +5,7 @@ export {
   convertSemesterEnumToString,
   convertSemesterToEnum,
   extractYearFromSemester,
+  getExamReviewProcessStatuses,
   getStatusName,
+  isExamReviewSanctioned,
 } from './exam-formatters';

--- a/src/pages/reviews/ExamReviewPage.tsx
+++ b/src/pages/reviews/ExamReviewPage.tsx
@@ -23,6 +23,7 @@ import type {
 import {
   convertExamTypeEnumToString,
   convertSemesterEnumToString,
+  getExamReviewProcessStatuses,
 } from '@/domains/Reviews/utils';
 
 import { getExamReviewDetail } from '@/apis';
@@ -277,7 +278,8 @@ export default function ExamReviewPage() {
                   nextStatus ??
                   updatedDetail.status ??
                   (updatedDetail.isConfirmed ? 'CONFIRMED' : 'UNCONFIRMED'),
-                reviewTitle: updatedDetail.title,
+                reviewTitle:
+                  updatedDetail.title ?? selectedExamReview.reviewTitle,
                 courseName,
                 professor,
                 semester,
@@ -286,10 +288,10 @@ export default function ExamReviewPage() {
                 questionDetail: updatedDetail.questionDetail,
                 uploadTime,
                 userDisplay: updatedDetail.userDisplay,
-                isDiscussed: selectedExamReview.isDiscussed,
+                isDiscussed: updatedDetail.isDiscussed,
                 isReported: selectedExamReview.isReported,
                 reportCount: selectedExamReview.reportCount,
-                processStatuses: selectedExamReview.processStatuses,
+                processStatuses: getExamReviewProcessStatuses(updatedDetail),
               };
 
               updatedData[itemIndex] = updatedItem;

--- a/src/pages/reviews/ExamReviewPage.tsx
+++ b/src/pages/reviews/ExamReviewPage.tsx
@@ -214,108 +214,96 @@ export default function ExamReviewPage() {
     });
   };
 
-  const handleSaveSuccess = async (nextStatus?: string) => {
+  const handleSaveSuccess = async (
+    updatedDetailFromSave?: ExamReviewDetailResult
+  ) => {
     // 쿼리 캐시를 직접 업데이트하여 스켈레톤 없이 즉시 반영
     if (selectedExamReview && selectedExamReviewDetail) {
-      // 저장 후 최신 상세 정보 가져오기 (백그라운드)
       try {
-        const response = await getExamReviewDetail(selectedExamReview.id);
-        if (response.isSuccess && response.result) {
-          const updatedDetail = response.result;
+        let updatedDetail: ExamReviewDetailResult;
 
-          // 현재 검색 파라미터로 쿼리 키 생성
-          const queryKey = [
-            'examReviews',
-            currentPage,
-            searchParams.startDate,
-            searchParams.endDate,
-            searchParams.keywordAuthor,
-            searchParams.keywordPost,
-            searchParams.sort,
-            searchParams.lectureYear,
-            searchParams.semester,
-            searchParams.examType,
-            searchParams.isConfirmed,
-            searchParams.isDiscussed,
-            searchParams.isReported,
-            searchParams.statuses,
-            refreshKey,
-          ];
+        if (updatedDetailFromSave !== undefined) {
+          updatedDetail = updatedDetailFromSave;
+        } else {
+          const response = await getExamReviewDetail(selectedExamReview.id);
 
-          // 캐시에서 현재 데이터 가져오기
-          const cachedData = queryClient.getQueryData<{
-            data: ExamReview[];
-            hasNext: boolean;
-          }>(queryKey);
-
-          if (cachedData) {
-            // 선택된 항목의 인덱스 찾기
-            const itemIndex = cachedData.data.findIndex(
-              (item) => item.id === selectedExamReview.id
+          if (!response.isSuccess || !response.result) {
+            throw new Error(
+              response.message ||
+                '시험 후기 상세 정보를 불러오는데 실패했습니다.'
             );
-
-            if (itemIndex !== -1) {
-              // 선택된 항목의 상태를 업데이트된 상태로 변경
-              const updatedData = [...cachedData.data];
-
-              const courseName = updatedDetail.lectureName || '';
-              const professor = updatedDetail.professor || '';
-              const semester = convertSemesterEnumToString(
-                updatedDetail.semester,
-                updatedDetail.lectureYear
-              );
-              const examType = convertExamTypeEnumToString(
-                updatedDetail.examType
-              );
-              const classNumber = String(updatedDetail.classNumber ?? '');
-              const uploadTime = formatDateTimeToMinutes(
-                updatedDetail.createdAt
-              );
-
-              const updatedItem: ExamReview = {
-                id: updatedDetail.postId,
-                status:
-                  nextStatus ??
-                  updatedDetail.status ??
-                  (updatedDetail.isConfirmed ? 'CONFIRMED' : 'UNCONFIRMED'),
-                reviewTitle:
-                  updatedDetail.title ?? selectedExamReview.reviewTitle,
-                courseName,
-                professor,
-                semester,
-                examType,
-                classNumber,
-                questionDetail: updatedDetail.questionDetail,
-                uploadTime,
-                userDisplay: updatedDetail.userDisplay,
-                isDiscussed: updatedDetail.isDiscussed,
-                isReported: selectedExamReview.isReported,
-                reportCount: selectedExamReview.reportCount,
-                processStatuses: getExamReviewProcessStatuses(updatedDetail),
-              };
-
-              updatedData[itemIndex] = updatedItem;
-
-              // 캐시 업데이트 (스켈레톤 없이 즉시 반영)
-              queryClient.setQueryData(queryKey, {
-                ...cachedData,
-                data: updatedData,
-              });
-
-              // 선택된 항목도 업데이트
-              setSelectedExamReview(updatedItem);
-              setSelectedExamReviewDetail((prev) => {
-                if (!prev) return updatedDetail;
-                if (!nextStatus) return updatedDetail;
-                return {
-                  ...prev,
-                  ...updatedDetail,
-                  status: nextStatus,
-                } as ExamReviewDetailResult;
-              });
-            }
           }
+
+          updatedDetail = response.result;
         }
+
+        // 현재 검색 파라미터로 쿼리 키 생성
+        const queryKey = [
+          'examReviews',
+          currentPage,
+          searchParams.startDate,
+          searchParams.endDate,
+          searchParams.keywordAuthor,
+          searchParams.keywordPost,
+          searchParams.sort,
+          searchParams.lectureYear,
+          searchParams.semester,
+          searchParams.examType,
+          searchParams.isConfirmed,
+          searchParams.isDiscussed,
+          searchParams.isReported,
+          searchParams.statuses,
+          refreshKey,
+        ];
+
+        const courseName = updatedDetail.lectureName || '';
+        const professor = updatedDetail.professor || '';
+        const semester = convertSemesterEnumToString(
+          updatedDetail.semester,
+          updatedDetail.lectureYear
+        );
+        const examType = convertExamTypeEnumToString(updatedDetail.examType);
+        const classNumber = String(updatedDetail.classNumber ?? '');
+        const uploadTime = formatDateTimeToMinutes(updatedDetail.createdAt);
+
+        const updatedItem: ExamReview = {
+          id: updatedDetail.postId,
+          status:
+            updatedDetail.status ??
+            (updatedDetail.isConfirmed ? 'CONFIRMED' : 'UNCONFIRMED'),
+          reviewTitle: updatedDetail.title ?? selectedExamReview.reviewTitle,
+          courseName,
+          professor,
+          semester,
+          examType,
+          classNumber,
+          questionDetail: updatedDetail.questionDetail,
+          uploadTime,
+          userDisplay: updatedDetail.userDisplay,
+          isDiscussed: updatedDetail.isDiscussed,
+          isReported: selectedExamReview.isReported,
+          reportCount: selectedExamReview.reportCount,
+          processStatuses: getExamReviewProcessStatuses(updatedDetail),
+        };
+
+        // 캐시에서 현재 데이터 가져오기
+        const cachedData = queryClient.getQueryData<{
+          data: ExamReview[];
+          hasNext: boolean;
+        }>(queryKey);
+
+        if (cachedData) {
+          queryClient.setQueryData(queryKey, {
+            ...cachedData,
+            data: cachedData.data.map((item) =>
+              item.id === selectedExamReview.id ? updatedItem : item
+            ),
+          });
+        }
+
+        // 선택된 항목도 업데이트
+        setSelectedExamReview(updatedItem);
+        setSelectedExamReviewDetail(updatedDetail);
       } catch (error) {
         // 에러 발생 시 기존 방식으로 fallback
         console.error('Failed to update cache:', error);

--- a/src/pages/reviews/ExamReviewPage.tsx
+++ b/src/pages/reviews/ExamReviewPage.tsx
@@ -110,6 +110,27 @@ export default function ExamReviewPage() {
       params.isConfirmed = false;
     }
 
+    const isDiscussed = searchParamsFromUrl.get('isDiscussed');
+    if (isDiscussed === 'true') {
+      params.isDiscussed = true;
+    }
+    if (isDiscussed === 'false') {
+      params.isDiscussed = false;
+    }
+
+    const isReported = searchParamsFromUrl.get('isReported');
+    if (isReported === 'true') {
+      params.isReported = true;
+    }
+    if (isReported === 'false') {
+      params.isReported = false;
+    }
+
+    const statuses = searchParamsFromUrl.get('statuses');
+    if (statuses) {
+      params.statuses = statuses;
+    }
+
     // 실제로 검색 파라미터가 변경되었는지 확인
     const hasChanged =
       params.startDate !== searchParams.startDate ||
@@ -120,7 +141,10 @@ export default function ExamReviewPage() {
       params.lectureYear !== searchParams.lectureYear ||
       params.semester !== searchParams.semester ||
       params.examType !== searchParams.examType ||
-      params.isConfirmed !== searchParams.isConfirmed;
+      params.isConfirmed !== searchParams.isConfirmed ||
+      params.isDiscussed !== searchParams.isDiscussed ||
+      params.isReported !== searchParams.isReported ||
+      params.statuses !== searchParams.statuses;
 
     if (hasChanged) {
       setSearchParams(params);
@@ -157,6 +181,15 @@ export default function ExamReviewPage() {
     }
     if (params.isConfirmed !== undefined) {
       newSearchParams.set('isConfirmed', String(params.isConfirmed));
+    }
+    if (params.isDiscussed !== undefined) {
+      newSearchParams.set('isDiscussed', String(params.isDiscussed));
+    }
+    if (params.isReported !== undefined) {
+      newSearchParams.set('isReported', String(params.isReported));
+    }
+    if (params.statuses) {
+      newSearchParams.set('statuses', params.statuses);
     }
     // 검색 시 첫 페이지로 이동
     newSearchParams.set('page', '1');
@@ -202,6 +235,9 @@ export default function ExamReviewPage() {
             searchParams.semester,
             searchParams.examType,
             searchParams.isConfirmed,
+            searchParams.isDiscussed,
+            searchParams.isReported,
+            searchParams.statuses,
             refreshKey,
           ];
 
@@ -250,6 +286,10 @@ export default function ExamReviewPage() {
                 questionDetail: updatedDetail.questionDetail,
                 uploadTime,
                 userDisplay: updatedDetail.userDisplay,
+                isDiscussed: selectedExamReview.isDiscussed,
+                isReported: selectedExamReview.isReported,
+                reportCount: selectedExamReview.reportCount,
+                processStatuses: selectedExamReview.processStatuses,
               };
 
               updatedData[itemIndex] = updatedItem;
@@ -391,6 +431,21 @@ export default function ExamReviewPage() {
                   ? false
                   : undefined
             }
+            initialIsDiscussed={
+              searchParamsFromUrl.get('isDiscussed') === 'true'
+                ? true
+                : searchParamsFromUrl.get('isDiscussed') === 'false'
+                  ? false
+                  : undefined
+            }
+            initialIsReported={
+              searchParamsFromUrl.get('isReported') === 'true'
+                ? true
+                : searchParamsFromUrl.get('isReported') === 'false'
+                  ? false
+                  : undefined
+            }
+            initialStatuses={searchParamsFromUrl.get('statuses') || ''}
             initialStartDate={searchParamsFromUrl.get('startDate') || ''}
           />
         </div>

--- a/src/shared/constants/exam-table-options.ts
+++ b/src/shared/constants/exam-table-options.ts
@@ -7,6 +7,17 @@ export const EXAM_CONFIRM_STATUS = [
   { code: 'DELETED', label: '삭제됨' },
 ] as const;
 
+// 시험후기 게시글 처리 상태 리스트
+export const EXAM_REVIEW_PROCESS_STATUS = [
+  { code: 'VISIBLE', label: '노출' },
+  { code: 'USER_DELETED', label: '유저 삭제' },
+  { code: 'ADMIN_DELETED', label: '어드민 삭제' },
+  { code: 'ADMIN_HIDDEN', label: '어드민 비공개' },
+  { code: 'AUTO_HIDDEN', label: '비공개 (신고 5개 이상)' },
+  { code: 'SANCTIONED', label: '징계' },
+  { code: 'DESANCTIONED', label: '징계 없음' },
+] as const;
+
 // 수강 학기 자동 생성 함수 (2007년 ~ 현재년도)
 const generateSemesterList = (): string[] => {
   const currentYear = new Date().getFullYear();


### PR DESCRIPTION

  - 시험후기 목록 필터 추가
      - 논의 여부, 신고 여부, 처리 상태 필터 추가
      - URL query param과 검색 상태 동기화

  - 시험후기 목록 테이블 개선
      - 논의 여부, 신고 여부, 처리상태 컬럼 추가
      - 신고 수 표시
      - 처리 상태 배지 표시
      - 컬럼 증가에 맞춰 스켈레톤/빈 행 처리 개선

  - 시험후기 상세 조회 개선
      - 상세 조회 API를 /v1/admin/reviews/{postId}로 변경
      - 삭제 상태, 징계 여부, 공개 상태, 메모, 관리 이력 데이터 반영
      - 상세 화면에 상태 배지와 메모 필드 추가

  - 시험후기 수정 기능 개선
      - 논의 여부와 메모 수정 지원
      - 파일 변경 감지 기준 개선
      - 수정 성공 시 응답 데이터로 목록/상세 캐시 즉시 갱신
      - post 데이터를 multipart Blob(application/json)으로 전송하도록
        변경

  - 확인 처리와 상세 수정 요청 분리
      - 확인 여부 변경은 확인 처리 API로 분리
      - 상세 내용 변경은 수정 API로 처리
      - 두 변경이 같이 있을 때도 순차 처리 후 화면 상태 갱신

  - 관리 이력 탭 추가
      - 상세 화면에 관리 이력 탭 추가
      - 변경 일시, 관리자, 변경 내용을 테이블로 표시

  - 검색/정렬 관련 정리
      - 시험후기 정렬 옵션에서 신고순(REPORT) 제거
      - 학기 문자열 → enum 변환 로직 보정

  - 어드민 사이트 검색 노출 방지
      - index.html에 robots noindex, nofollow 메타 태그 추가
      - public/_headers에 X-Robots-Tag: noindex, nofollow 추가