### PR TITLE
feat: 게시글 댓글 관리 회원 팝오버 기능 구현

### DIFF
--- a/src/apis/users.ts
+++ b/src/apis/users.ts
@@ -2,6 +2,7 @@ import { axiosInstance } from '@/shared/axios/instance';
 import type {
   AdminUserListResponse,
   EditMemberInfo,
+  MemberInfo,
   UpdateUserInfoResponse,
 } from '@/shared/types';
 
@@ -30,4 +31,13 @@ export const editUsersAPI = async (
     data
   );
   return response.data;
+};
+
+export const getUserDetailAPI = async (
+  encryptedUserId: string
+): Promise<MemberInfo> => {
+  const response = await axiosInstance.get(
+    `/v1/admin/users/${encryptedUserId}`
+  );
+  return response.data.result;
 };

--- a/src/domains/Comments/components/CommentTable.tsx
+++ b/src/domains/Comments/components/CommentTable.tsx
@@ -39,11 +39,6 @@ export default function CommentTable({
     isAllSelected,
     selectAllRef,
     handleSelectAll,
-    activePopoverId,
-    setActivePopoverId,
-    popoverUser,
-    isUserLoading,
-    handleNicknameClick,
     handleSingleVisibility,
     handleFilterByPostId,
     handleFilterByParentId,
@@ -64,10 +59,7 @@ export default function CommentTable({
   const isEmpty = !isLoading && comments.length === 0;
 
   return (
-    <div
-      className='flex flex-col gap-3'
-      onClick={() => setActivePopoverId(null)}
-    >
+    <div className='flex flex-col gap-3'>
       <CommentBulkActionBar
         selectedCount={selectedIds.length}
         isVisibilityPending={isVisibilityPending}
@@ -180,12 +172,6 @@ export default function CommentTable({
                           : [...prev, id]
                       );
                     }}
-                    activePopoverId={activePopoverId}
-                    onNicknameClick={handleNicknameClick}
-                    popoverUser={popoverUser}
-                    isUserLoading={isUserLoading}
-                    onClosePopover={() => setActivePopoverId(null)}
-                    onPageChange={onPageChange}
                     onSingleVisibilityToggle={handleSingleVisibility}
                     onFilterByPostId={handleFilterByPostId}
                     onFilterByParentId={handleFilterByParentId}

--- a/src/domains/Comments/components/CommentTableRow.tsx
+++ b/src/domains/Comments/components/CommentTableRow.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { AlertTriangle, Heart } from 'lucide-react';
@@ -6,7 +5,6 @@ import { AlertTriangle, Heart } from 'lucide-react';
 import MemberInfoPopover from '@/shared/components/MemberInfoPopover';
 import { Badge, Table } from '@/shared/components/ui';
 import { cn } from '@/shared/lib';
-import type { MemberInfo } from '@/shared/types';
 import { formatDateTimeWithAmPm } from '@/shared/utils';
 
 import type { AdminCommentResponse } from '../types/comment';
@@ -22,12 +20,6 @@ interface CommentTableRowProps {
   comment: AdminCommentResponse;
   isSelected: boolean;
   onSelectToggle: (id: number) => void;
-  activePopoverId: number | null;
-  onNicknameClick: (e: React.MouseEvent, comment: AdminCommentResponse) => void;
-  popoverUser: MemberInfo | null;
-  isUserLoading: boolean;
-  onClosePopover: () => void;
-  onPageChange: (page: number | ((prev: number) => number)) => void;
   onSingleVisibilityToggle: (comment: AdminCommentResponse) => void;
   onFilterByPostId: (postId: number) => void;
   onFilterByParentId: (parentId: number) => void;
@@ -37,11 +29,6 @@ export default function CommentTableRow({
   comment,
   isSelected,
   onSelectToggle,
-  activePopoverId,
-  onNicknameClick,
-  popoverUser,
-  isUserLoading,
-  onClosePopover,
   onSingleVisibilityToggle,
   onFilterByPostId,
   onFilterByParentId,
@@ -135,21 +122,11 @@ export default function CommentTableRow({
       </Table.Cell>
 
       {/* 6. 작성자(닉네임) */}
-      <Table.Cell
-        className='relative cursor-pointer px-3 font-bold text-gray-900 select-none'
-        onClick={(e) => onNicknameClick(e, comment)}
-      >
-        <div className='truncate transition-colors hover:text-blue-700 hover:underline'>
-          {comment.nickname || comment.userDisplay}
-        </div>
-        {activePopoverId === comment.commentId && (
-          <MemberInfoPopover
-            encryptedUserId={comment.encryptedUserId}
-            popoverUser={popoverUser}
-            isUserLoading={isUserLoading}
-            onClose={onClosePopover}
-          />
-        )}
+      <Table.Cell className='relative cursor-pointer px-3 font-bold text-gray-900 select-none'>
+        <MemberInfoPopover
+          encryptedUserId={comment.encryptedUserId}
+          displayName={comment.nickname ?? '정보 없음'}
+        />
       </Table.Cell>
 
       {/* 7. 게시판 */}

--- a/src/domains/Comments/hooks/useCommentTableState.ts
+++ b/src/domains/Comments/hooks/useCommentTableState.ts
@@ -3,12 +3,6 @@ import { useNavigate } from 'react-router-dom';
 
 import { toast } from 'sonner';
 
-import type { MemberInfo } from '@/shared/types';
-
-import { extractFirstSearchMember } from '@/domains/MemberInfo/utils/memberDirectory';
-
-import { searchUsersAPI } from '@/apis/users';
-
 import type { AdminCommentResponse } from '../types/comment';
 import { getCommentStatus } from '../utils/commentUtils';
 import { useBulkDeleteComment } from './useBulkDeleteComment';
@@ -43,28 +37,6 @@ export function useCommentTableState({
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
   const [sortBy] = useState<'reportCount' | 'createdAt'>('createdAt');
   const [sortDir] = useState<'asc' | 'desc'>('desc');
-
-  // 닉네임 클릭 팝오버 상태
-  const [activePopoverId, setActivePopoverId] = useState<number | null>(null);
-  const [popoverUser, setPopoverUser] = useState<MemberInfo | null>(null);
-  const [isUserLoading, setIsUserLoading] = useState(false);
-
-  // 검색 조건 변경 시 선택 초기화 및 팝오버 닫기
-  useEffect(() => {
-    setSelectedIds([]);
-    setActivePopoverId(null);
-  }, [
-    searchParams.content,
-    searchParams.postId,
-    searchParams.parentId,
-    searchParams.encryptedUserId,
-    searchParams.boardId,
-    searchParams.isVisible,
-    searchParams.isKeywordExist,
-    searchParams.startDate,
-    searchParams.endDate,
-    searchParams.status,
-  ]);
 
   const { data, isLoading, refetch } = useCommentList({
     page: currentPage,
@@ -199,56 +171,6 @@ export function useCommentTableState({
     }
   };
 
-  // 닉네임 클릭 핸들러
-  const handleNicknameClick = async (
-    e: React.MouseEvent,
-    comment: AdminCommentResponse
-  ) => {
-    e.stopPropagation();
-
-    if (activePopoverId === comment.commentId) {
-      setActivePopoverId(null);
-      setPopoverUser(null);
-      return;
-    }
-
-    setActivePopoverId(comment.commentId);
-    setPopoverUser(null);
-    setIsUserLoading(true);
-
-    try {
-      const res = await searchUsersAPI(comment.nickname || comment.userDisplay);
-      const member = extractFirstSearchMember(res?.result);
-      if (member) {
-        setPopoverUser(member);
-      } else {
-        setPopoverUser({
-          encryptedUserId: comment.encryptedUserId,
-          loginId: '정보 없음',
-          userName: comment.nickname || comment.userDisplay,
-          email: '',
-          nickname: comment.nickname || comment.userDisplay,
-          userRoleId: 1,
-          studentNumber: '정보 없음',
-          major: '정보 없음',
-          birthday: '',
-          pointBalance: 0,
-          createdAt: '',
-          authenticatedAt: null,
-          totalWarningCount: 0,
-          isBlacklist: false,
-          blacklistStartDate: null,
-          blacklistEndDate: null,
-        });
-      }
-    } catch (err) {
-      console.error(err);
-      toast.error('회원 상세 조회에 실패했습니다.');
-    } finally {
-      setIsUserLoading(false);
-    }
-  };
-
   // 비공개 해제 / 삭제 복구 단건 토글 액션
   const handleSingleVisibility = (comment: AdminCommentResponse) => {
     const isCurrentlyVisible = comment.isVisible;
@@ -294,11 +216,6 @@ export function useCommentTableState({
     isSomeSelected,
     selectAllRef,
     handleSelectAll,
-    activePopoverId,
-    setActivePopoverId,
-    popoverUser,
-    isUserLoading,
-    handleNicknameClick,
     handleSingleVisibility,
     handleFilterByPostId,
     handleFilterByParentId,

--- a/src/domains/Comments/types/comment.ts
+++ b/src/domains/Comments/types/comment.ts
@@ -7,7 +7,6 @@ export interface AdminCommentResponse {
   isVisible: boolean;
   isKeywordExist: boolean;
   createdAt: string;
-  userDisplay: string;
   nickname: string;
   content: string;
   reportCount: number;

--- a/src/domains/Posts/components/PostDetail/PostDetailCommentItem.tsx
+++ b/src/domains/Posts/components/PostDetail/PostDetailCommentItem.tsx
@@ -1,4 +1,4 @@
-import { type MouseEvent, useState } from 'react';
+import { useState } from 'react';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { AlertTriangle, CornerDownRight, Heart } from 'lucide-react';
@@ -6,7 +6,6 @@ import { toast } from 'sonner';
 
 import { MemberInfoPopover } from '@/shared/components';
 import { Badge, Button } from '@/shared/components/ui';
-import type { MemberInfo } from '@/shared/types';
 import { formatDateTimeWithAmPm } from '@/shared/utils';
 
 import type { AdminCommentResponse } from '@/domains/Comments/types';
@@ -14,9 +13,8 @@ import {
   getCommentStatus,
   getCommentStatusBadge,
 } from '@/domains/Comments/utils/commentUtils';
-import { extractFirstSearchMember } from '@/domains/MemberInfo/utils/memberDirectory';
 
-import { deleteComment, searchUsersAPI, updateCommentVisibility } from '@/apis';
+import { deleteComment, updateCommentVisibility } from '@/apis';
 
 interface PostDetailCommentItemProps {
   comment: AdminCommentResponse;
@@ -28,10 +26,6 @@ export default function PostDetailCommentItem({
   const queryClient = useQueryClient();
   const status = getCommentStatus(comment);
   const isSubComment = comment.parentId !== null;
-  // 회원 팝오버 상태
-  const [activePopoverId, setActivePopoverId] = useState<number | null>(null);
-  const [popoverUser, setPopoverUser] = useState<MemberInfo | null>(null);
-  const [isUserLoading, setIsUserLoading] = useState(false);
   // 댓글 상태 변경 모달 상태
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalType, setModalType] = useState<'HIDE' | 'SHOW' | 'DELETE'>(
@@ -39,53 +33,6 @@ export default function PostDetailCommentItem({
   );
   const [reason, setReason] = useState('');
 
-  // 작성자 닉네임 클릭 처리
-  const handleNicknameClick = async (e: MouseEvent) => {
-    e.stopPropagation();
-
-    if (activePopoverId === comment.commentId) {
-      setActivePopoverId(null);
-      setPopoverUser(null);
-      return;
-    }
-
-    setActivePopoverId(comment.commentId);
-    setPopoverUser(null);
-    setIsUserLoading(true);
-
-    try {
-      const display = comment.nickname || comment.userDisplay || '익명';
-      const res = await searchUsersAPI(display);
-      const member = extractFirstSearchMember(res?.result);
-      if (member) {
-        setPopoverUser(member);
-      } else {
-        setPopoverUser({
-          encryptedUserId: comment.encryptedUserId,
-          loginId: '정보 없음',
-          userName: display,
-          email: '',
-          nickname: display,
-          userRoleId: 1,
-          studentNumber: '정보 없음',
-          major: '정보 없음',
-          birthday: '',
-          pointBalance: 0,
-          createdAt: '',
-          authenticatedAt: null,
-          totalWarningCount: 0,
-          isBlacklist: false,
-          blacklistStartDate: null,
-          blacklistEndDate: null,
-        });
-      }
-    } catch (err) {
-      console.error(err);
-      toast.error('회원 상세 조회에 실패했습니다.');
-    } finally {
-      setIsUserLoading(false);
-    }
-  };
   // 댓글 노출/숨김 변경 Mutation
   const visibilityMutation = useMutation({
     mutationFn: (isVisible: boolean) =>
@@ -131,10 +78,6 @@ export default function PostDetailCommentItem({
     <div
       key={comment.commentId}
       className={`flex items-start gap-3 ${isSubComment ? 'pl-8' : ''}`}
-      onClick={() => {
-        setActivePopoverId(null);
-        setPopoverUser(null);
-      }}
     >
       {isSubComment && (
         <CornerDownRight className='mt-2.5 h-4 w-4 shrink-0 text-gray-400' />
@@ -144,12 +87,10 @@ export default function PostDetailCommentItem({
         {/* 상단 헤더: 닉네임 + 일시 및 액션 버튼 */}
         <div className='flex items-start justify-between gap-4'>
           <div className='flex flex-wrap items-center gap-x-2 gap-y-0.5'>
-            <span
-              className='cursor-pointer text-sm font-bold text-gray-800 hover:text-blue-600 hover:underline'
-              onClick={handleNicknameClick}
-            >
-              {comment.nickname || comment.userDisplay || '익명'}
-            </span>
+            <MemberInfoPopover
+              encryptedUserId={comment.encryptedUserId}
+              displayName={comment.nickname}
+            />
             <span className='font-mono text-xs text-gray-400'>
               {formatDateTimeWithAmPm(comment.createdAt)}
             </span>
@@ -247,24 +188,6 @@ export default function PostDetailCommentItem({
             {comment.reportCount ?? 0}
           </span>
         </div>
-
-        {/* 닉네임 팝오버 렌더링 */}
-        {activePopoverId === comment.commentId && (
-          <div
-            className='absolute top-8 left-10 z-50'
-            onClick={(e) => e.stopPropagation()}
-          >
-            <MemberInfoPopover
-              encryptedUserId={comment.encryptedUserId}
-              popoverUser={popoverUser}
-              isUserLoading={isUserLoading}
-              onClose={() => {
-                setActivePopoverId(null);
-                setPopoverUser(null);
-              }}
-            />
-          </div>
-        )}
       </div>
       {/* 댓글 조치 사유 기입 모달 */}
       {isModalOpen && comment && (

--- a/src/domains/Posts/components/PostDetail/PostDetailInfoPanel.tsx
+++ b/src/domains/Posts/components/PostDetail/PostDetailInfoPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import { useState } from 'react';
 
 import DOMPurify from 'dompurify';
 import { Bookmark, Heart, MessageSquare } from 'lucide-react';
@@ -6,16 +6,11 @@ import { toast } from 'sonner';
 
 import MemberInfoPopover from '@/shared/components/MemberInfoPopover';
 import { Badge, Switch } from '@/shared/components/ui';
-import type { MemberInfo } from '@/shared/types';
 import { formatDateTimeWithAmPm } from '@/shared/utils';
 import {
   getPostStatus,
   getPostStatusBadges,
 } from '@/shared/utils/postCommentUtils';
-
-import { extractFirstSearchMember } from '@/domains/MemberInfo/utils/memberDirectory';
-
-import { searchUsersAPI } from '@/apis';
 
 import type { AdminGetPostResponse } from '../../types/post';
 
@@ -28,11 +23,6 @@ export default function PostDetailInfoPanel({
 }: PostDetailInfoPanelProps) {
   const [isNotice, setIsNotice] = useState(post.isNotice);
   const status = getPostStatus(post);
-  // 닉네임 팝오버 상태
-  const [activePopoverId, setActivePopoverId] = useState<number | null>(null);
-  const [popoverUser, setPopoverUser] = useState<MemberInfo | null>(null);
-  const [isUserLoading, setIsUserLoading] = useState(false);
-
   const handleNoticeToggle = (checked: boolean) => {
     setIsNotice(checked);
     toast.success(
@@ -41,60 +31,6 @@ export default function PostDetailInfoPanel({
         : '해당 게시글의 공지 등록이 해제되었습니다.'
     );
   };
-
-  // 작성자 닉네임 클릭 처리
-  const handleNicknameClick = useCallback(
-    async (
-      e: React.MouseEvent,
-      targetPost: { nickName?: string; encryptedUserId: string; postId: number }
-    ) => {
-      e.stopPropagation();
-
-      if (activePopoverId === targetPost.postId) {
-        setActivePopoverId(null);
-        setPopoverUser(null);
-        return;
-      }
-
-      setActivePopoverId(targetPost.postId);
-      setPopoverUser(null);
-      setIsUserLoading(true);
-
-      try {
-        const display = targetPost.nickName || '익명';
-        const res = await searchUsersAPI(display);
-        const member = extractFirstSearchMember(res?.result);
-        if (member) {
-          setPopoverUser(member);
-        } else {
-          setPopoverUser({
-            encryptedUserId: targetPost.encryptedUserId,
-            loginId: '정보 없음',
-            userName: display,
-            email: '',
-            nickname: display,
-            userRoleId: 1,
-            studentNumber: '정보 없음',
-            major: '정보 없음',
-            birthday: '',
-            pointBalance: 0,
-            createdAt: '',
-            authenticatedAt: null,
-            totalWarningCount: 0,
-            isBlacklist: false,
-            blacklistStartDate: null,
-            blacklistEndDate: null,
-          });
-        }
-      } catch (err) {
-        console.error(err);
-        toast.error('회원 상세 조회에 실패했습니다.');
-      } finally {
-        setIsUserLoading(false);
-      }
-    },
-    [activePopoverId]
-  );
 
   return (
     <div className='relative flex flex-col gap-6 rounded-xl border border-gray-200 bg-white p-6 shadow-sm'>
@@ -164,12 +100,11 @@ export default function PostDetailInfoPanel({
           <div className='relative flex flex-col gap-1'>
             <span className='font-medium text-gray-400'>작성자</span>
             <div>
-              <span
-                className='cursor-pointer text-sm font-bold text-blue-600 underline transition-colors hover:text-blue-800'
-                onClick={(e) => handleNicknameClick(e, post)}
-              >
-                {post.nickName || '익명'}
-              </span>
+              <MemberInfoPopover
+                encryptedUserId={post.encryptedUserId}
+                displayName={post.nickName ?? '정보 없음'}
+              />
+
               <span className='ml-1 text-xs text-gray-400'>
                 (
                 {post.encryptedUserId
@@ -178,24 +113,6 @@ export default function PostDetailInfoPanel({
                 )
               </span>
             </div>
-
-            {/* 닉네임 팝오버 렌더링 */}
-            {activePopoverId === post.postId && (
-              <div
-                className='absolute top-12 left-0 z-50'
-                onClick={(e) => e.stopPropagation()}
-              >
-                <MemberInfoPopover
-                  encryptedUserId={post.encryptedUserId}
-                  popoverUser={popoverUser}
-                  isUserLoading={isUserLoading}
-                  onClose={() => {
-                    setActivePopoverId(null);
-                    setPopoverUser(null);
-                  }}
-                />
-              </div>
-            )}
           </div>
         </div>
       </div>

--- a/src/domains/Posts/components/PostTable.tsx
+++ b/src/domains/Posts/components/PostTable.tsx
@@ -36,11 +36,6 @@ export default function PostTable({
     isAllSelected,
     selectAllRef,
     handleSelectAll,
-    activePopoverId,
-    setActivePopoverId,
-    popoverUser,
-    isUserLoading,
-    handleNicknameClick,
     handleBulkDelete,
     handleBulkVisibility,
     handleBulkRestore,
@@ -57,10 +52,7 @@ export default function PostTable({
   const isEmpty = !isLoading && posts.length === 0;
 
   return (
-    <div
-      className='flex flex-col gap-3'
-      onClick={() => setActivePopoverId(null)}
-    >
+    <div className='flex flex-col gap-3'>
       <PostBulkActionBar
         selectedCount={selectedIds.length}
         isVisibilityPending={isVisibilityPending}
@@ -167,12 +159,6 @@ export default function PostTable({
                           : [...prev, id]
                       );
                     }}
-                    activePopoverId={activePopoverId}
-                    onNicknameClick={handleNicknameClick}
-                    popoverUser={popoverUser}
-                    isUserLoading={isUserLoading}
-                    onClosePopover={() => setActivePopoverId(null)}
-                    onPageChange={onPageChange}
                   />
                 ))
               )}

--- a/src/domains/Posts/components/PostTableRow.tsx
+++ b/src/domains/Posts/components/PostTableRow.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import {
@@ -9,10 +8,9 @@ import {
   MessageSquare,
 } from 'lucide-react';
 
-import MemberInfoPopover from '@/shared/components/MemberInfoPopover';
+import { MemberInfoPopover } from '@/shared/components';
 import { Badge, Table } from '@/shared/components/ui';
 import { cn } from '@/shared/lib';
-import type { MemberInfo } from '@/shared/types';
 import { formatDateTimeWithAmPm } from '@/shared/utils';
 import {
   formatPostId,
@@ -27,23 +25,12 @@ interface PostTableRowProps {
   post: AdminGetPostResponse;
   isSelected: boolean;
   onSelectToggle: (id: number) => void;
-  activePopoverId: number | null;
-  onNicknameClick: (e: React.MouseEvent, post: AdminGetPostResponse) => void;
-  popoverUser: MemberInfo | null;
-  isUserLoading: boolean;
-  onClosePopover: () => void;
-  onPageChange: (page: number | ((prev: number) => number)) => void;
 }
 
 export default function PostTableRow({
   post,
   isSelected,
   onSelectToggle,
-  activePopoverId,
-  onNicknameClick,
-  popoverUser,
-  isUserLoading,
-  onClosePopover,
 }: PostTableRowProps) {
   const navigate = useNavigate();
   const status = getPostStatus(post);
@@ -53,10 +40,7 @@ export default function PostTableRow({
       className={cn('border-b border-gray-100 last:border-0 [&_td]:h-[54px]')}
     >
       {/* 0. Checkbox */}
-      <Table.Cell
-        className='px-3 text-center'
-        onClick={(e) => e.stopPropagation()}
-      >
+      <Table.Cell className='px-3 text-center'>
         <input
           type='checkbox'
           checked={isSelected}
@@ -64,7 +48,7 @@ export default function PostTableRow({
             e.stopPropagation();
             onSelectToggle(post.postId);
           }}
-          className='cursor-pointer rounded border-gray-300'
+          className='rounded border-gray-300'
         />
       </Table.Cell>
 
@@ -105,21 +89,11 @@ export default function PostTableRow({
       </Table.Cell>
 
       {/* 3. 작성자(닉네임) */}
-      <Table.Cell
-        className='relative cursor-pointer px-3 font-bold text-gray-900 select-none'
-        onClick={(e) => onNicknameClick(e, post)}
-      >
-        <div className='truncate transition-colors hover:text-blue-700 hover:underline'>
-          {post.nickName || '익명송이'}
-        </div>
-        {activePopoverId === post.postId && (
-          <MemberInfoPopover
-            encryptedUserId={post.encryptedUserId}
-            popoverUser={popoverUser}
-            isUserLoading={isUserLoading}
-            onClose={onClosePopover}
-          />
-        )}
+      <Table.Cell className='relative cursor-pointer px-3 font-bold text-gray-900'>
+        <MemberInfoPopover
+          encryptedUserId={post.encryptedUserId}
+          displayName={post.nickName ?? '정보 없음'}
+        />
       </Table.Cell>
 
       {/* 4. 게시판 */}

--- a/src/domains/Posts/hooks/usePostTableState.ts
+++ b/src/domains/Posts/hooks/usePostTableState.ts
@@ -2,12 +2,6 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { toast } from 'sonner';
 
-import type { MemberInfo } from '@/shared/types';
-
-import { extractFirstSearchMember } from '@/domains/MemberInfo/utils/memberDirectory';
-
-import { searchUsersAPI } from '@/apis/users';
-
 import type { AdminGetPostResponse } from '../types/post';
 import { useBulkDeletePost } from './useBulkDeletePost';
 import { useDeletePost } from './useDeletePost';
@@ -35,13 +29,8 @@ export function usePostTableState({
 }: UsePostTableStateProps) {
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
 
-  const [activePopoverId, setActivePopoverId] = useState<number | null>(null);
-  const [popoverUser, setPopoverUser] = useState<MemberInfo | null>(null);
-  const [isUserLoading, setIsUserLoading] = useState(false);
-
   useEffect(() => {
     setSelectedIds([]);
-    setActivePopoverId(null);
   }, [
     searchParams.encryptedUserId,
     searchParams.boardId,
@@ -213,56 +202,6 @@ export function usePostTableState({
     }
   };
 
-  const handleNicknameClick = async (
-    e: React.MouseEvent,
-    post: AdminGetPostResponse
-  ) => {
-    e.stopPropagation();
-
-    if (activePopoverId === post.postId) {
-      setActivePopoverId(null);
-      setPopoverUser(null);
-      return;
-    }
-
-    setActivePopoverId(post.postId);
-    setPopoverUser(null);
-    setIsUserLoading(true);
-
-    try {
-      const display = post.nickName || '익명';
-      const res = await searchUsersAPI(display);
-      const member = extractFirstSearchMember(res?.result);
-      if (member) {
-        setPopoverUser(member);
-      } else {
-        setPopoverUser({
-          encryptedUserId: post.encryptedUserId,
-          loginId: '정보 없음',
-          userName: display,
-          email: '',
-          nickname: display,
-          userRoleId: 1,
-          studentNumber: '정보 없음',
-          major: '정보 없음',
-          birthday: '',
-          pointBalance: 0,
-          createdAt: '',
-          authenticatedAt: null,
-          totalWarningCount: 0,
-          isBlacklist: false,
-          blacklistStartDate: null,
-          blacklistEndDate: null,
-        });
-      }
-    } catch (err) {
-      console.error(err);
-      toast.error('회원 상세 조회에 실패했습니다.');
-    } finally {
-      setIsUserLoading(false);
-    }
-  };
-
   return {
     posts,
     isLoading,
@@ -273,11 +212,6 @@ export function usePostTableState({
     isSomeSelected,
     selectAllRef,
     handleSelectAll,
-    activePopoverId,
-    setActivePopoverId,
-    popoverUser,
-    isUserLoading,
-    handleNicknameClick,
     handleBulkDelete,
     handleBulkVisibility,
     handleBulkRestore,

--- a/src/shared/components/MemberInfoModal.tsx
+++ b/src/shared/components/MemberInfoModal.tsx
@@ -1,0 +1,92 @@
+import { useNavigate } from 'react-router-dom';
+
+import { Button, Dialog } from '@/shared/components/ui';
+import type { MemberInfo } from '@/shared/types';
+
+interface MemberInfoModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  memberInfo: MemberInfo | null;
+  encryptedUserId: string;
+}
+
+export default function MemberInfoModal({
+  isOpen,
+  onClose,
+  memberInfo,
+  encryptedUserId,
+}: MemberInfoModalProps) {
+  const navigate = useNavigate();
+  if (!memberInfo) return null;
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <Dialog.Content className='sm:max-w-md'>
+        <Dialog.Header>
+          <Dialog.Title>회원 정보</Dialog.Title>
+        </Dialog.Header>
+        {memberInfo && (
+          <div className='grid grid-cols-[auto_1fr] gap-x-6 gap-y-2.5 py-2 text-sm'>
+            <span className='text-gray-500'>이름</span>
+            <span className='font-medium text-gray-900'>
+              {memberInfo.userName}
+            </span>
+            <span className='text-gray-500'>아이디</span>
+            <span className='font-medium text-gray-900'>
+              {memberInfo.loginId}
+            </span>
+            <span className='text-gray-500'>학번</span>
+            <span className='font-medium text-gray-900'>
+              {memberInfo.studentNumber}
+            </span>
+            <span className='text-gray-500'>닉네임</span>
+            <span className='font-medium text-gray-900'>
+              {memberInfo.nickname}
+            </span>
+            <span className='text-gray-500'>포인트</span>
+            <span className='font-medium text-gray-900'>
+              {memberInfo.pointBalance.toLocaleString()}P
+            </span>
+            <span className='text-gray-500'>경고 이력</span>
+            <span className='font-medium text-gray-900'>
+              {memberInfo.totalWarningCount}회
+            </span>
+            <span className='text-gray-500'>강등 이력</span>
+            <span className='font-medium text-gray-900'>
+              {memberInfo.isBlacklist
+                ? (memberInfo.blacklistType ?? '강등 중')
+                : '없음'}
+            </span>
+          </div>
+        )}
+        <Dialog.Footer>
+          <Button variant='outline' onClick={onClose}>
+            닫기
+          </Button>
+          <Button
+            onClick={() => {
+              onClose();
+              navigate(`/member/info/${encryptedUserId}`, {
+                state: {
+                  prefetchedMember: memberInfo,
+                  detailKeywords: [
+                    memberInfo.loginId,
+                    memberInfo.studentNumber,
+                    memberInfo.userName,
+                  ],
+                },
+              });
+            }}
+          >
+            유저 상세 페이지로 이동
+          </Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/src/shared/components/MemberInfoPopover.tsx
+++ b/src/shared/components/MemberInfoPopover.tsx
@@ -1,113 +1,130 @@
-import { useNavigate } from 'react-router-dom';
+import { useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
-import { Loader2, X } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
 
 import type { MemberInfo } from '@/shared/types';
 
+import { getUserDetailAPI } from '@/apis';
+
+import MemberInfoModal from './MemberInfoModal';
+import SanctionModal from './SanctionModal';
+
 interface MemberInfoPopoverProps {
   encryptedUserId: string;
-  popoverUser: MemberInfo | null;
-  isUserLoading: boolean;
-  onClose: () => void;
+  displayName: string;
 }
 
 export default function MemberInfoPopover({
   encryptedUserId,
-  popoverUser,
-  isUserLoading,
-  onClose,
+  displayName,
 }: MemberInfoPopoverProps) {
-  const navigate = useNavigate();
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const [popoverPos, setPopoverPos] = useState({ top: 0, left: 0 });
+  const [memberInfo, setMemberInfo] = useState<MemberInfo | null>(null);
+  const [isFetching, setIsFetching] = useState(false);
+  const [isInfoModalOpen, setIsInfoModalOpen] = useState(false);
+  const [isSanctionModalOpen, setIsSanctionModalOpen] = useState(false);
+
+  const handleTriggerClick = () => {
+    if (!isPopoverOpen && triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect();
+      setPopoverPos({ top: rect.bottom + 4, left: rect.left });
+    }
+    setIsPopoverOpen((prev) => !prev);
+  };
+
+  const fetchMemberInfo = async (): Promise<MemberInfo | null> => {
+    if (memberInfo) return memberInfo;
+    setIsFetching(true);
+    try {
+      const member = await getUserDetailAPI(encryptedUserId);
+      setMemberInfo(member);
+      return member;
+    } catch {
+      toast.error('회원 정보를 불러오지 못했습니다.');
+      return null;
+    } finally {
+      setIsFetching(false);
+    }
+  };
+
+  const handleInfoClick = async () => {
+    setIsPopoverOpen(false);
+    const member = await fetchMemberInfo();
+    if (member) setIsInfoModalOpen(true);
+  };
+
+  const handleSanctionClick = async () => {
+    setIsPopoverOpen(false);
+    const member = await fetchMemberInfo();
+    if (member) setIsSanctionModalOpen(true);
+  };
 
   return (
-    <div
-      className='border-gray-250 absolute top-10 left-3 z-50 w-72 rounded-lg border bg-white p-4 text-xs leading-relaxed font-normal text-gray-700 shadow-xl'
-      onClick={(e) => e.stopPropagation()}
-    >
-      <div className='mb-2 flex items-center justify-between border-b border-gray-100 pb-2'>
-        <span className='font-bold text-gray-900'>미니 회원 정보</span>
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onClose();
-          }}
-          className='rounded p-0.5 hover:bg-gray-100'
-        >
-          <X className='h-3.5 w-3.5 text-gray-400' />
-        </button>
-      </div>
+    <div>
+      <span
+        ref={triggerRef}
+        onClick={handleTriggerClick}
+        className='cursor-pointer truncate transition-colors hover:text-blue-700 hover:underline'
+      >
+        {displayName}
+      </span>
 
-      {isUserLoading ? (
-        <div className='flex justify-center py-4'>
-          <Loader2 className='h-5 w-5 animate-spin text-blue-600' />
-        </div>
-      ) : popoverUser ? (
-        <div className='flex flex-col gap-2'>
-          <div className='mb-1 grid grid-cols-2 gap-x-2 gap-y-1 border-b border-gray-50 pb-2 text-gray-600'>
-            <div>
-              이름:{' '}
-              <strong className='text-gray-900'>
-                {popoverUser.userName || '미정'}
-              </strong>
-            </div>
-            <div>
-              아이디:{' '}
-              <strong className='font-mono text-gray-900'>
-                {popoverUser.loginId || '미정'}
-              </strong>
-            </div>
-            <div>
-              학번:{' '}
-              <strong className='font-mono text-gray-900'>
-                {popoverUser.studentNumber || '미정'}
-              </strong>
-            </div>
-            <div>
-              포인트:{' '}
-              <strong className='font-bold text-blue-600'>
-                {popoverUser.pointBalance || 0} P
-              </strong>
-            </div>
-            <div>
-              강등이력:{' '}
-              <strong
-                className={
-                  popoverUser.isBlacklist
-                    ? 'font-semibold text-red-600'
-                    : 'text-gray-900'
-                }
-              >
-                {popoverUser.isBlacklist ? '있음' : '없음'}
-              </strong>
-            </div>
-            <div>
-              경고횟수:{' '}
-              <strong
-                className={
-                  (popoverUser.totalWarningCount ?? 0) > 0
-                    ? 'font-semibold text-red-600'
-                    : 'text-gray-900'
-                }
-              >
-                {popoverUser.totalWarningCount ?? 0} 회
-              </strong>
-            </div>
-          </div>
-          <button
-            onClick={() => {
-              onClose();
-              const params = new URLSearchParams();
-              params.set('encryptedUserId', encryptedUserId);
-              navigate(`?${params.toString()}`, { replace: true });
-            }}
-            className='w-full rounded px-2 py-1 text-left font-medium text-gray-800 hover:bg-blue-50 hover:text-blue-700'
-          >
-            작성한 댓글 검색 조회
-          </button>
-        </div>
-      ) : (
-        <p className='py-2 text-center text-gray-400'>사용자 상세 조회 실패</p>
+      {isFetching && (
+        <Loader2 className='ml-1 inline h-3 w-3 animate-spin text-gray-400' />
       )}
+
+      {isPopoverOpen &&
+        createPortal(
+          <>
+            <div
+              className='fixed inset-0 z-40'
+              onClick={() => setIsPopoverOpen(false)}
+            />
+            <div
+              className='fixed z-50 w-48 overflow-hidden rounded-lg border border-gray-200 bg-white py-1 shadow-lg'
+              style={{ top: popoverPos.top, left: popoverPos.left }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <button
+                className='w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50'
+                onClick={handleInfoClick}
+              >
+                회원 정보
+              </button>
+              <button className='w-full cursor-not-allowed px-3 py-2 text-left text-sm text-gray-400'>
+                작성한 게시글
+              </button>
+              <button className='w-full cursor-not-allowed px-3 py-2 text-left text-sm text-gray-400'>
+                작성한 댓글
+              </button>
+              <div className='border-t border-gray-100' />
+              <button
+                className='w-full px-3 py-2 text-left text-sm font-medium text-red-600 hover:bg-red-50'
+                onClick={handleSanctionClick}
+              >
+                제재하기
+              </button>
+            </div>
+          </>,
+          document.body
+        )}
+
+      <MemberInfoModal
+        isOpen={isInfoModalOpen}
+        onClose={() => setIsInfoModalOpen(false)}
+        memberInfo={memberInfo}
+        encryptedUserId={encryptedUserId}
+      />
+
+      <SanctionModal
+        isOpen={isSanctionModalOpen}
+        onClose={() => setIsSanctionModalOpen(false)}
+        memberInfo={memberInfo}
+      />
     </div>
   );
 }

--- a/src/shared/components/MemberInfoPopover.tsx
+++ b/src/shared/components/MemberInfoPopover.tsx
@@ -38,6 +38,7 @@ export default function MemberInfoPopover({
 
   const fetchMemberInfo = async (): Promise<MemberInfo | null> => {
     if (memberInfo) return memberInfo;
+    if (isFetching) return null;
     setIsFetching(true);
     try {
       const member = await getUserDetailAPI(encryptedUserId);

--- a/src/shared/components/SanctionModal.tsx
+++ b/src/shared/components/SanctionModal.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+
+import { Button, Dialog } from '@/shared/components/ui';
+import type { MemberInfo } from '@/shared/types';
+
+import PenaltyHistoryAddDialog from '@/domains/MemberInfo/components/penalty-history/PenaltyHistoryAddDialog';
+import type { AddPenaltyMode } from '@/domains/MemberInfo/components/penalty-history/penalty-history-add-utils';
+
+interface SanctionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  memberInfo: MemberInfo | null;
+}
+
+export default function SanctionModal({
+  isOpen,
+  onClose,
+  memberInfo,
+}: SanctionModalProps) {
+  const [penaltyMode, setPenaltyMode] = useState<AddPenaltyMode | null>(null);
+
+  if (!memberInfo) return null;
+
+  return (
+    <>
+      <Dialog
+        open={isOpen}
+        onOpenChange={(open) => {
+          if (!open) onClose();
+        }}
+      >
+        <Dialog.Content className='sm:max-w-xs'>
+          <Dialog.Header>
+            <Dialog.Title>제재 유형 선택</Dialog.Title>
+            <Dialog.Description>
+              {memberInfo.userName}님에게 적용할 제재 유형을 선택하세요.
+            </Dialog.Description>
+          </Dialog.Header>
+          <div className='flex gap-3 py-2'>
+            <Button
+              className='flex-1'
+              variant='outline'
+              onClick={() => {
+                onClose();
+                setPenaltyMode('WARNING');
+              }}
+            >
+              경고
+            </Button>
+            <Button
+              className='flex-1 bg-red-600 text-white hover:bg-red-700'
+              onClick={() => {
+                onClose();
+                setPenaltyMode('DEMOTION');
+              }}
+            >
+              강등
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog>
+
+      <PenaltyHistoryAddDialog
+        member={memberInfo}
+        mode={penaltyMode}
+        onOpenChange={(open) => {
+          if (!open) setPenaltyMode(null);
+        }}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## 🔎 What is this PR?

Close #282

- [Figma]()
- [Notion]()

## 🎯 변경 사항

###### 주요 변경점을 설명해주세요.

### 1. MemberInfoPopover 사용 방식 리팩토링

* **프로퍼티(Props) 단순화**: 댓글 및 게시글 상세 컴포넌트(`CommentTableRow`, `PostDetailCommentItem`, `PostDetailInfoPanel`)에서 `MemberInfoPopover`를 사용하는 모든 코드를 수정했습니다. 이제 부모 컴포넌트가 팝오버 상태를 관리하거나 유저 정보를 직접 조회할 필요 없이 `encryptedUserId`와 `displayName`만 전달하면 됩니다.
* **불필요한 상태 및 핸들러 제거**: 부모 컴포넌트와 관련 훅에서 팝오버 관련 상태 및 핸들러(`activePopoverId`, `popoverUser`, `isUserLoading`, `handleNicknameClick` 등)를 모두 제거하여 컴포넌트 로직을 대폭 단순화했습니다. (대상 파일: `CommentTable`, `CommentTableRow`, `PostDetailCommentItem`, `PostDetailInfoPanel`, `useCommentTableState`)

### 2. 백엔드 API 및 타입 추가

* **상세 조회 API 추가**: 유저 API에 `encryptedUserId`로 회원 상세 정보를 조회하는 `getUserDetailAPI` 함수를 새로 추가했으며, 필요한 곳에 `MemberInfo` 타입을 임포트했습니다.

### 3. 코드 정리 (Clean-up)

* **의존성 제거**: 이번 리팩토링으로 인해 더 이상 사용하지 않게 된 유저/회원 검색 관련 임포트문, 유틸리티 함수, API 호출 및 팝오버 상태 관리 로직을 관련 파일에서 모두 제거했습니다.

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
