### PR TITLE
feat: 시험후기 신고 상태 표시 및   필터 UI 개선

### DIFF
--- a/src/domains/Reviews/components/ExamReviewPostInfoSection.tsx
+++ b/src/domains/Reviews/components/ExamReviewPostInfoSection.tsx
@@ -16,7 +16,7 @@ export function ExamReviewPostInfoSection({
   return (
     <div className='grid grid-cols-1 gap-y-4 md:grid-cols-2 md:gap-x-4'>
       <Field className='gap-0'>
-        <Field.Label>시험 후기 ID</Field.Label>
+        <Field.Label>postId</Field.Label>
         <div className='flex h-9 items-center rounded-md border border-gray-200 bg-gray-50 px-3 text-sm text-gray-700'>
           {postId ?? ''}
         </div>

--- a/src/domains/Reviews/components/ExamSearch.tsx
+++ b/src/domains/Reviews/components/ExamSearch.tsx
@@ -130,7 +130,7 @@ export default function ExamSearch({
     getBooleanFilterValue(initialIsDiscussed)
   );
   const [reportStatus, setReportStatus] = useState<string>(
-    getBooleanFilterValue(initialIsReported)
+    initialIsReported === true ? TRUE_SELECTED : ALL_SELECTED
   );
   const [selectedStatuses, setSelectedStatuses] = useState<string[]>(
     getStatusLabelsFromCodes(initialStatuses)
@@ -237,10 +237,6 @@ export default function ExamSearch({
 
     if (targetReportStatus === TRUE_SELECTED) {
       params.isReported = true;
-    }
-
-    if (targetReportStatus === FALSE_SELECTED) {
-      params.isReported = false;
     }
 
     const statuses = getStatusCodesFromLabels(targetSelectedStatuses);
@@ -513,29 +509,6 @@ export default function ExamSearch({
           </Select.Content>
         </Select>
 
-        <Select
-          value={reportStatus}
-          onValueChange={(value) => {
-            setReportStatus(value);
-            handleSearchWithParams({ reportStatus: value });
-          }}
-        >
-          <Select.Trigger className='h-9 w-[150px] text-sm'>
-            <Select.Value />
-          </Select.Trigger>
-          <Select.Content align='start'>
-            <Select.Item value={ALL_SELECTED} className='text-sm'>
-              신고 여부 전체
-            </Select.Item>
-            <Select.Item value={TRUE_SELECTED} className='text-sm'>
-              신고 있음
-            </Select.Item>
-            <Select.Item value={FALSE_SELECTED} className='text-sm'>
-              신고 없음
-            </Select.Item>
-          </Select.Content>
-        </Select>
-
         <ExamMultiSelect
           value={selectedStatuses}
           onValueChange={(value) => {
@@ -558,6 +531,22 @@ export default function ExamSearch({
             <ChevronDown className='size-4 opacity-50' />
           </Button>
         </ExamMultiSelect>
+
+        <label className='border-input flex h-9 cursor-pointer items-center gap-2 rounded-md border bg-white px-3 text-sm font-normal'>
+          <input
+            type='checkbox'
+            checked={reportStatus === TRUE_SELECTED}
+            onChange={(e) => {
+              const nextReportStatus = e.target.checked
+                ? TRUE_SELECTED
+                : ALL_SELECTED;
+              setReportStatus(nextReportStatus);
+              handleSearchWithParams({ reportStatus: nextReportStatus });
+            }}
+            className='relative h-3.5 w-3.5 shrink-0 cursor-pointer appearance-none rounded border-2 border-gray-300 bg-transparent checked:border-blue-500 checked:bg-blue-500 checked:before:absolute checked:before:inset-0 checked:before:flex checked:before:items-center checked:before:justify-center checked:before:text-[9px] checked:before:text-white checked:before:content-["✓"]'
+          />
+          <span>신고 있음</span>
+        </label>
       </div>
     </div>
   );

--- a/src/domains/Reviews/components/ExamTable.tsx
+++ b/src/domains/Reviews/components/ExamTable.tsx
@@ -118,7 +118,10 @@ const EXAM_REVIEW_TABLE_COLUMNS: ExamReviewTableColumn[] = [
     label: '확인여부',
     width: '78px',
     render: (review: ExamReview) => (
-      <ExamConfirmStatusBadge status={review.status} />
+      <ExamConfirmStatusBadge
+        status={review.status}
+        className='justify-center'
+      />
     ),
   },
   { key: 'id', label: 'postId', width: '90px' },
@@ -235,7 +238,10 @@ export default function ExamTable({
               {EXAM_REVIEW_TABLE_COLUMNS.map((column) => (
                 <Table.Head
                   key={column.key}
-                  className='relative cursor-pointer overflow-hidden text-ellipsis whitespace-nowrap'
+                  className={cn(
+                    'relative cursor-pointer overflow-hidden text-ellipsis whitespace-nowrap',
+                    column.key === 'status' && 'text-center'
+                  )}
                 >
                   {column.label}
                 </Table.Head>
@@ -276,6 +282,7 @@ export default function ExamTable({
                           key={column.key}
                           className={cn(
                             'overflow-hidden text-ellipsis whitespace-nowrap',
+                            column.key === 'status' && 'text-center',
                             column.key === 'processStatuses' &&
                               'whitespace-normal'
                           )}

--- a/src/domains/Reviews/components/ExamTable.tsx
+++ b/src/domains/Reviews/components/ExamTable.tsx
@@ -75,18 +75,15 @@ const renderBooleanBadge = (
   </Badge>
 );
 
-const renderReportBadge = (review: ExamReview) => {
-  const label = review.isReported ? `신고 ${review.reportCount}` : '신고 없음';
+const renderReportedStatusBadge = (review: ExamReview) => {
+  if (!review.isReported) return null;
+
+  const label = `신고 ${review.reportCount}`;
 
   return (
     <Badge
       variant='outline'
-      className={cn(
-        'max-w-full truncate',
-        review.isReported
-          ? 'border-red-200 bg-red-50 text-red-700 dark:bg-red-950 dark:text-red-300'
-          : 'text-gray-500 dark:text-gray-400'
-      )}
+      className='max-w-full truncate border-red-200 bg-red-50 text-red-700 dark:bg-red-950 dark:text-red-300'
       title={label}
     >
       {label}
@@ -95,10 +92,13 @@ const renderReportBadge = (review: ExamReview) => {
 };
 
 const renderProcessStatusBadge = (review: ExamReview) => {
-  const label = review.processStatuses.map(getProcessStatusLabel).join(', ');
+  const statusLabels = review.processStatuses.map(getProcessStatusLabel);
+  const reportLabel = review.isReported ? `신고 ${review.reportCount}` : null;
+  const label = [reportLabel, ...statusLabels].filter(Boolean).join(', ');
 
   return (
     <div className='flex flex-wrap gap-1' title={label}>
+      {renderReportedStatusBadge(review)}
       {review.processStatuses.map((status) => (
         <Badge
           key={status}
@@ -132,15 +132,9 @@ const EXAM_REVIEW_TABLE_COLUMNS: ExamReviewTableColumn[] = [
       renderBooleanBadge(review.isDiscussed, '논의 있음', '논의 없음'),
   },
   {
-    key: 'isReported',
-    label: '신고 여부',
-    width: '92px',
-    render: renderReportBadge,
-  },
-  {
     key: 'processStatuses',
-    label: '처리상태',
-    width: '92px',
+    label: '관리 상태',
+    width: '150px',
     render: renderProcessStatusBadge,
   },
   { key: 'uploadTime', label: '작성일', width: '150px' },

--- a/src/domains/Reviews/components/ExamTableFallback.tsx
+++ b/src/domains/Reviews/components/ExamTableFallback.tsx
@@ -1,6 +1,6 @@
 import { Skeleton, Table } from '@/shared/components/ui';
 
-const DEFAULT_EXAM_TABLE_COLUMN_COUNT = 8;
+const DEFAULT_EXAM_TABLE_COLUMN_COUNT = 7;
 
 // ======= types =======
 interface ExamTableSkeletonProps {

--- a/src/pages/reviews/ExamReviewPage.tsx
+++ b/src/pages/reviews/ExamReviewPage.tsx
@@ -123,9 +123,6 @@ export default function ExamReviewPage() {
     if (isReported === 'true') {
       params.isReported = true;
     }
-    if (isReported === 'false') {
-      params.isReported = false;
-    }
 
     const statuses = searchParamsFromUrl.get('statuses');
     if (statuses) {
@@ -431,9 +428,7 @@ export default function ExamReviewPage() {
             initialIsReported={
               searchParamsFromUrl.get('isReported') === 'true'
                 ? true
-                : searchParamsFromUrl.get('isReported') === 'false'
-                  ? false
-                  : undefined
+                : undefined
             }
             initialStatuses={searchParamsFromUrl.get('statuses') || ''}
             initialStartDate={searchParamsFromUrl.get('startDate') || ''}

--- a/src/shared/constants/exam-table-options.ts
+++ b/src/shared/constants/exam-table-options.ts
@@ -1,6 +1,6 @@
 // 상태 리스트
 export const EXAM_CONFIRM_STATUS = [
-  { code: 'CONFIRMED', label: '확인완료' },
+  { code: 'CONFIRMED', label: '확인' },
   { code: 'UNCONFIRMED', label: '미확인' },
   { code: 'NEED_DISCUSS', label: '논의필요' },
   { code: 'NEED_ACTION', label: '징계필요' },


### PR DESCRIPTION
## 🔎 What is this PR?

Close #291


## 🎯 변경 사항

###### 주요 변경점을 설명해주세요.

  - 시험후기 관리 테이블에서 신고 여부 컬럼 제거

  - 신고가 있는 시험후기는 관리 상태 컬럼에 신고 N 배지로 표시

  - 관리 상태 컬럼 너비 및 테이블 fallback 컬럼 수 조정

  - 확인완료 라벨을 확인으로 변경
  - 시험후기 관리 테이블의 확인여부 컬럼 헤 더/셀 가운데 정렬

  - 신고 여부 검색 필터를 드롭다운에서 신고  있음 체크박스로 변경

  - 신고 있음 체크박스를 처리 상태 필터 오른쪽에 배치

  - isReported=false URL 파라미터는 체크박스 UI와 맞지 않아 필터로 반영하지 않도록 정리

  - 시험후기 상세 정보의 시험 후기 ID 라벨을 postId로 변경
 
## 📸 스크린샷 (선택 사항)


| Before | After |
| :----: | :---: |
|  | <img width="2940" height="1670" alt="image" src="https://github.com/user-attachments/assets/99e7da58-501d-43b4-9e96-c9202cc70880" /> |


## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
