### PR TITLE
fix: Access Token 만료 시 자동 로그인 연장 오류 해결

### DIFF
--- a/src/shared/axios/instance.ts
+++ b/src/shared/axios/instance.ts
@@ -1,10 +1,11 @@
 import axios, {
-  type AxiosInstance,
   type AxiosError,
+  type AxiosInstance,
   type InternalAxiosRequestConfig,
 } from 'axios';
-import { tokenStorage, executeTokenRefresh } from '@/shared/utils';
+
 import { REISSUE_TOKEN_ENDPOINT } from '@/shared/constants';
+import { executeTokenRefresh, tokenStorage } from '@/shared/utils';
 
 class AxiosInstanceManager {
   private static instance: AxiosInstance | null = null;
@@ -46,7 +47,11 @@ class AxiosInstanceManager {
         (config: InternalAxiosRequestConfig) => {
           const accessToken = tokenStorage.getAccessToken();
 
-          if (accessToken && config.headers) {
+          if (
+            accessToken &&
+            config.headers &&
+            config.url !== REISSUE_TOKEN_ENDPOINT
+          ) {
             config.headers.Authorization = `Bearer ${accessToken}`;
           }
 

--- a/src/shared/utils/token-manager.ts
+++ b/src/shared/utils/token-manager.ts
@@ -30,7 +30,12 @@ export async function executeTokenRefresh(): Promise<{
 
       // 새로운 토큰 저장
       tokenStorage.setAccessToken(newAccessToken, ACCESS_TOKEN_EXPIRE_MINUTES);
-      tokenStorage.setRefreshToken(newRefreshToken, REFRESH_TOKEN_EXPIRE_DAYS);
+      if (newRefreshToken) {
+        tokenStorage.setRefreshToken(
+          newRefreshToken,
+          REFRESH_TOKEN_EXPIRE_DAYS
+        );
+      }
 
       return { success: true, accessToken: newAccessToken };
     }

--- a/src/shared/utils/token-manager.ts
+++ b/src/shared/utils/token-manager.ts
@@ -28,6 +28,10 @@ export async function executeTokenRefresh(): Promise<{
       const { accessToken: newAccessToken, refreshToken: newRefreshToken } =
         response.result;
 
+      if (!newAccessToken) {
+        return { success: false };
+      }
+
       // 새로운 토큰 저장
       tokenStorage.setAccessToken(newAccessToken, ACCESS_TOKEN_EXPIRE_MINUTES);
       if (newRefreshToken) {


### PR DESCRIPTION
## 🔎 What is this PR?

Close #293 

- [Figma]()
- [Notion]()

## 🎯 변경 사항

###### 주요 변경점을 설명해주세요
### 1. 토큰 재발급 요청 시 **Authorization** 헤더 생략
- Axios 요청 인터셉터에서 현재 요청 URL이 `REISSUE_TOKEN_ENDPOINT`일 경우, `Authorization` 헤더를 추가하지 않도록 예외 조건을 추가했습니다.
### 2. Refresh Token 덮어쓰기 방지 조건 추가
토큰 재발급 응답 결과에 새로운 `newRefreshToken`이 명확히 존재하는 경우에만 쿠키를 교체하도록 수정했습니다.

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
