### PR TITLE
feat: 미지급 일정 목록에 기간 상태 배지 표시

### DIFF
--- a/src/domains/Points/components/PointFreezeListSection.test.tsx
+++ b/src/domains/Points/components/PointFreezeListSection.test.tsx
@@ -13,15 +13,31 @@ describe('PointFreezeListSection', () => {
     vi.useRealTimers();
   });
 
-  test('미지급 일정 목록에서 기간 상태 배지를 보여준다', () => {
+  test('미지급 일정 목록에서 기간 상태 배지를 올바르게 보여준다', () => {
     render(
       <PointFreezeListSection
         pointFreezes={[
           {
             id: 1,
-            title: '정산 점검',
+            title: '진행중 일정',
             startAt: '2026-01-15 00:00:00',
             endAt: '2026-01-16 00:00:00',
+            createdAt: '2026-01-01 10:00:00',
+            updatedAt: '2026-01-01 10:00:00',
+          },
+          {
+            id: 2,
+            title: '예정된 일정',
+            startAt: '2026-01-16 00:00:00',
+            endAt: '2026-01-17 00:00:00',
+            createdAt: '2026-01-01 10:00:00',
+            updatedAt: '2026-01-01 10:00:00',
+          },
+          {
+            id: 3,
+            title: '종료된 일정',
+            startAt: '2026-01-13 00:00:00',
+            endAt: '2026-01-14 00:00:00',
             createdAt: '2026-01-01 10:00:00',
             updatedAt: '2026-01-01 10:00:00',
           },
@@ -34,9 +50,13 @@ describe('PointFreezeListSection', () => {
       screen.getByRole('columnheader', { name: '상태' })
     ).toBeInTheDocument();
 
-    const row = screen.getByText('정산 점검').closest('tr');
+    const inProgressRow = screen.getByText('진행중 일정').closest('tr')!;
+    expect(within(inProgressRow).getByText('진행중')).toBeInTheDocument();
 
-    expect(row).not.toBeNull();
-    expect(within(row as HTMLElement).getByText('진행중')).toBeInTheDocument();
+    const scheduledRow = screen.getByText('예정된 일정').closest('tr')!;
+    expect(within(scheduledRow).getByText('예정')).toBeInTheDocument();
+
+    const endedRow = screen.getByText('종료된 일정').closest('tr')!;
+    expect(within(endedRow).getByText('종료')).toBeInTheDocument();
   });
 });

--- a/src/domains/Points/components/PointFreezeListSection.test.tsx
+++ b/src/domains/Points/components/PointFreezeListSection.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { PointFreezeListSection } from './PointFreezeListSection';
+
+describe('PointFreezeListSection', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-15T12:00:00'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('미지급 일정 목록에서 기간 상태 배지를 보여준다', () => {
+    render(
+      <PointFreezeListSection
+        pointFreezes={[
+          {
+            id: 1,
+            title: '정산 점검',
+            startAt: '2026-01-15 00:00:00',
+            endAt: '2026-01-16 00:00:00',
+            createdAt: '2026-01-01 10:00:00',
+            updatedAt: '2026-01-01 10:00:00',
+          },
+        ]}
+        getPointFreezes={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole('columnheader', { name: '상태' })
+    ).toBeInTheDocument();
+
+    const row = screen.getByText('정산 점검').closest('tr');
+
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).getByText('진행중')).toBeInTheDocument();
+  });
+});

--- a/src/domains/Points/components/PointFreezeListSection.tsx
+++ b/src/domains/Points/components/PointFreezeListSection.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { MoreHorizontalIcon } from 'lucide-react';
 
+import { PeriodStatusBadge } from '@/shared/components';
 import { Button, DropdownMenu, Table } from '@/shared/components/ui';
 import type { PointFreeze } from '@/shared/types';
 import { formatDateTimeToMinutes } from '@/shared/utils';
@@ -48,6 +49,7 @@ export function PointFreezeListSection({
             <Table.Header>
               <Table.Row className='text-center'>
                 <Table.Head className='text-center'>번호</Table.Head>
+                <Table.Head className='text-center'>상태</Table.Head>
                 <Table.Head className='text-center'>일정 제목</Table.Head>
                 <Table.Head className='text-center'>시작 일시</Table.Head>
                 <Table.Head className='text-center'>종료 일시</Table.Head>
@@ -66,6 +68,9 @@ export function PointFreezeListSection({
                     <Table.Row key={id}>
                       <Table.Cell className='text-center'>
                         {index + 1}
+                      </Table.Cell>
+                      <Table.Cell className='text-center'>
+                        <PeriodStatusBadge startAt={startAt} endAt={endAt} />
                       </Table.Cell>
                       <Table.Cell className='text-center'>{title}</Table.Cell>
                       <Table.Cell className='text-center'>


### PR DESCRIPTION
## 🔎 What is this PR?

Close #287


## 🎯 변경 사항

- 미지급 일정 목록 테이블에 `상태` 컬럼을 추가해 진행 상태를 바로 확인할 수 있도록 했습니다.
- 각 미지급 일정 행에 `startAt`/`endAt` 기반 `PeriodStatusBadge`를 렌더링합니다.
- `PointFreezeListSection`에 대한 렌더링 테스트를 추가해 상태 컬럼 및 진행중 배지 표시를 검증했습니다.

## 📸 스크린샷

<img width="2940" height="1602" alt="image" src="https://github.com/user-attachments/assets/1da3ffff-e20c-4990-85e4-e4422f0396e0" />

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)

- 상태 판정 기준(진행중/예정/종료)이 기존 배지와 일치하는지
- 상태 컬럼 추가로 테이블 정렬 및 레이아웃에 영향이 없는지
- 추가 테스트가 시간 기반 경계값에서 안정적으로 동작하는지
