### PR TITLE
refactor: 시험 리뷰 로그의 강의 유형 포맷팅 중복 제거

### DIFF
--- a/src/domains/Reviews/utils/exam-formatters.ts
+++ b/src/domains/Reviews/utils/exam-formatters.ts
@@ -189,10 +189,10 @@ export const getStatusName = (statusCode: string): string => {
 
 export const formatExamReviewLogValue = (
   key: string,
-  value: string | number | boolean | null,
+  value: string | number | boolean | null | undefined,
   statusModifiedReason?: string | number | boolean | null
 ): string => {
-  if (value === null) {
+  if (value == null) {
     return '-';
   }
 

--- a/src/domains/Reviews/utils/exam-formatters.ts
+++ b/src/domains/Reviews/utils/exam-formatters.ts
@@ -72,12 +72,10 @@ export const getExamReviewProcessStatuses = (
 
 /**
  * lectureType enum을 문자열로 변환
- * @param lectureTypeEnum - 변환할 lectureType enum 값
+ * @param lectureTypeEnum - 변환할 lectureType 값
  * @returns 한국어 문자열
  */
-export const convertLectureTypeToString = (
-  lectureTypeEnum: (typeof LECTURE_TYPE_OPTIONS)[number]['value']
-): string => {
+export const convertLectureTypeToString = (lectureTypeEnum: string): string => {
   return (
     LECTURE_TYPE_OPTIONS.find((option) => option.value === lectureTypeEnum)
       ?.label ?? lectureTypeEnum
@@ -237,10 +235,7 @@ export const formatExamReviewLogValue = (
   }
 
   if (key === 'lectureType') {
-    return (
-      LECTURE_TYPE_OPTIONS.find((option) => option.value === stringValue)
-        ?.label ?? stringValue
-    );
+    return convertLectureTypeToString(stringValue);
   }
 
   if (key === 'examType') {

--- a/src/domains/Reviews/utils/exam-formatters.ts
+++ b/src/domains/Reviews/utils/exam-formatters.ts
@@ -46,6 +46,8 @@ const formatStatusValue = (value: string): string =>
 const isBooleanString = (value: string): value is 'true' | 'false' =>
   value === 'true' || value === 'false';
 
+type LectureTypeValue = (typeof LECTURE_TYPE_OPTIONS)[number]['value'];
+
 export const isExamReviewSanctioned = (
   value: ExamReviewProcessStatusSource['isSanctioned']
 ): boolean => value === true || value === 'true';
@@ -75,7 +77,9 @@ export const getExamReviewProcessStatuses = (
  * @param lectureTypeEnum - 변환할 lectureType 값
  * @returns 한국어 문자열
  */
-export const convertLectureTypeToString = (lectureTypeEnum: string): string => {
+export const convertLectureTypeToString = (
+  lectureTypeEnum: LectureTypeValue | (string & {})
+): string => {
   return (
     LECTURE_TYPE_OPTIONS.find((option) => option.value === lectureTypeEnum)
       ?.label ?? lectureTypeEnum


### PR DESCRIPTION
## 🔎 What is this PR?

Close #306


## 🎯 변경 사항

###### 주요 변경점을 설명해주세요.

- 강의 유형 라벨 변환 함수가 문자열 입력을 처리하도록 타입 확장
- 시험 리뷰 로그의 강의 유형 포맷팅 로직을 공통 변환 함수로 재사용
- 시험 리뷰 로그 값이 null 또는 undefined인 경우 대시로 표시

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)

- 알 수 없는 강의 유형 값이 기존처럼 원문 그대로 표시되는지
- 시험 리뷰 로그에서 null과 undefined 값이 동일하게 대시로 표시되는지
