### PR TITLE
refactor: API 응답 타입을 BaseResponse<T>로 통일 및 Result 타입 분리

### DIFF
--- a/src/apis/alerts.ts
+++ b/src/apis/alerts.ts
@@ -1,7 +1,8 @@
 import { axiosInstance } from '@/shared/axios/instance';
-import type { PushNotification } from '@/shared/types';
+import type { BaseResponse, PushNotification } from '@/shared/types';
 
-export const postPushNotificationAPI = async (data: PushNotification) => {
-  const response = await axiosInstance.post('/v1/admin/alerts', data);
-  return response.data;
+export const postPushNotificationAPI = async (
+  data: PushNotification
+): Promise<void> => {
+  await axiosInstance.post<BaseResponse<void>>('/v1/admin/alerts', data);
 };

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,16 +1,17 @@
 import { axiosInstance } from '@/shared/axios/instance';
+import { REISSUE_TOKEN_ENDPOINT } from '@/shared/constants';
+import type { BaseResponse } from '@/shared/types';
 import type {
   LoginRequest,
-  LoginResponse,
+  LoginResult,
   ReissueTokenRequest,
-  ReissueTokenResponse,
+  TokenResponse,
 } from '@/shared/types';
-import { REISSUE_TOKEN_ENDPOINT } from '@/shared/constants';
 
 export const loginAPI = async (
   credentials: LoginRequest
-): Promise<LoginResponse> => {
-  const response = await axiosInstance.post<LoginResponse>(
+): Promise<BaseResponse<LoginResult>> => {
+  const response = await axiosInstance.post<BaseResponse<LoginResult>>(
     '/v1/users/login',
     credentials
   );
@@ -19,8 +20,8 @@ export const loginAPI = async (
 
 export const reissueTokenAPI = async (
   request: ReissueTokenRequest
-): Promise<ReissueTokenResponse> => {
-  const response = await axiosInstance.post<ReissueTokenResponse>(
+): Promise<BaseResponse<TokenResponse>> => {
+  const response = await axiosInstance.post<BaseResponse<TokenResponse>>(
     REISSUE_TOKEN_ENDPOINT,
     request
   );

--- a/src/apis/blacklist.ts
+++ b/src/apis/blacklist.ts
@@ -1,5 +1,6 @@
 import { axiosInstance } from '@/shared/axios/instance';
-import type { AdminBlacklistReq, AdminBlacklistResponse } from '@/shared/types';
+import type { BaseResponse } from '@/shared/types';
+import type { AdminBlacklistReq, AdminBlacklistResult } from '@/shared/types';
 
 // 블랙리스트 이력 불러오기
 export const blacklistHistoryAPI = async (
@@ -10,18 +11,17 @@ export const blacklistHistoryAPI = async (
     endDate?: string;
     type?: 'WARNING' | 'RELEGATION' | 'BLACKLIST';
   } = { page: 0 }
-): Promise<AdminBlacklistResponse> => {
-  const response = await axiosInstance.get<AdminBlacklistResponse>(
+): Promise<AdminBlacklistResult> => {
+  const response = await axiosInstance.get<BaseResponse<AdminBlacklistResult>>(
     `/v1/admin/blacklists/${encryptedUserId}`,
-    {
-      params,
-    }
+    { params }
   );
-  return response.data;
+  return response.data.result;
 };
 
 // 경고 및 강등 부여
-export const warnPenaltyAPI = async (data: AdminBlacklistReq) => {
-  const response = await axiosInstance.post('/v1/admin/blacklists', data);
-  return response.data;
+export const warnPenaltyAPI = async (
+  data: AdminBlacklistReq
+): Promise<void> => {
+  await axiosInstance.post<BaseResponse<void>>('/v1/admin/blacklists', data);
 };

--- a/src/apis/comments.ts
+++ b/src/apis/comments.ts
@@ -1,15 +1,16 @@
 import { axiosInstance } from '@/shared/axios/instance';
+import type { BaseResponse } from '@/shared/types';
 
 import type {
-  AdminCommentBulkDeleteResponse,
-  AdminCommentListResponse,
-  AdminCommentResponse,
+  AdminCommentBulkDeleteResult,
+  AdminCommentListResult,
+  AdminCommentResult,
   AdminCommentSearchRequest,
   AdminCommentVisibilityUpdateRequest,
-  AdminDeleteCommentResponse,
+  AdminDeleteCommentResult,
 } from '@/domains/Comments/types/comment';
 
-export interface PostCommentResponse {
+export interface PostCommentResult {
   id: number;
   postId: number;
   encryptedUserId: string;
@@ -25,34 +26,26 @@ export interface PostCommentResponse {
   isUpdated: boolean;
   isDeleted: boolean;
   isLiked: boolean;
-  children: PostCommentResponse[];
-}
-
-export interface GetPostCommentsResponse {
-  isSuccess: boolean;
-  code: number;
-  message: string;
-  result: {
-    hasNext: boolean;
-    data: PostCommentResponse[];
-  };
+  children: PostCommentResult[];
 }
 
 export const getPostCommentsAPI = async (
   postId: number,
   page: number
-): Promise<GetPostCommentsResponse> => {
-  const response = await axiosInstance.get(`/v1/posts/${postId}/comments`, {
-    params: { page },
-  });
-  return response.data;
+): Promise<{ hasNext: boolean; data: PostCommentResult[] }> => {
+  const response = await axiosInstance.get<
+    BaseResponse<{ hasNext: boolean; data: PostCommentResult[] }>
+  >(`/v1/posts/${postId}/comments`, { params: { page } });
+  return response.data.result;
 };
 
 // 댓글 상세 조회 api
 export const getComment = async (
   commentId: number
-): Promise<AdminCommentResponse> => {
-  const response = await axiosInstance.get(`/v1/admin/comments/${commentId}`);
+): Promise<AdminCommentResult> => {
+  const response = await axiosInstance.get<BaseResponse<AdminCommentResult>>(
+    `/v1/admin/comments/${commentId}`
+  );
   return response.data.result;
 };
 
@@ -60,11 +53,10 @@ export const getComment = async (
 export const getCommentChildrenList = async (
   commentId: number,
   page: number
-): Promise<AdminCommentListResponse> => {
-  const response = await axiosInstance.get(
-    `/v1/admin/comments/${commentId}/children`,
-    { params: { page } }
-  );
+): Promise<AdminCommentListResult> => {
+  const response = await axiosInstance.get<
+    BaseResponse<AdminCommentListResult>
+  >(`/v1/admin/comments/${commentId}/children`, { params: { page } });
   return response.data.result;
 };
 
@@ -72,8 +64,10 @@ export const getCommentChildrenList = async (
 export const searchComments = async (
   page: number,
   body: AdminCommentSearchRequest
-): Promise<AdminCommentListResponse> => {
-  const response = await axiosInstance.post('/v1/admin/comments/search', body, {
+): Promise<AdminCommentListResult> => {
+  const response = await axiosInstance.post<
+    BaseResponse<AdminCommentListResult>
+  >('/v1/admin/comments/search', body, {
     params: { page: page - 1 },
   });
   return response.data.result;
@@ -82,18 +76,20 @@ export const searchComments = async (
 // 댓글 삭제 api
 export const deleteComment = async (
   commentId: number
-): Promise<AdminDeleteCommentResponse> => {
-  const response = await axiosInstance.delete(
-    `/v1/admin/comments/${commentId}`
-  );
+): Promise<AdminDeleteCommentResult> => {
+  const response = await axiosInstance.delete<
+    BaseResponse<AdminDeleteCommentResult>
+  >(`/v1/admin/comments/${commentId}`);
   return response.data.result;
 };
 
 // 댓글 일괄 삭제 api
 export const bulkDeleteComments = async (
   commentIds: number[]
-): Promise<AdminCommentBulkDeleteResponse> => {
-  const response = await axiosInstance.delete(`/v1/admin/comments`, {
+): Promise<AdminCommentBulkDeleteResult> => {
+  const response = await axiosInstance.delete<
+    BaseResponse<AdminCommentBulkDeleteResult>
+  >(`/v1/admin/comments`, {
     data: { commentIds },
   });
   return response.data.result;
@@ -103,7 +99,7 @@ export const bulkDeleteComments = async (
 export const updateCommentVisibility = async (
   body: AdminCommentVisibilityUpdateRequest
 ): Promise<string> => {
-  const response = await axiosInstance.patch(
+  const response = await axiosInstance.patch<BaseResponse<string>>(
     `/v1/admin/comments/visibility`,
     body
   );

--- a/src/apis/inquiries.ts
+++ b/src/apis/inquiries.ts
@@ -1,15 +1,16 @@
 import { axiosInstance } from '@/shared/axios/instance';
+import type { BaseResponse } from '@/shared/types';
 import type {
   AdminInquiryCommentCreateRequest,
-  AdminInquiryCommentCreateResponse,
-  AdminInquiryCommentDeleteResponse,
-  AdminInquiryCommentListResponse,
+  AdminInquiryCommentCreateResult,
+  AdminInquiryCommentDeleteResult,
+  AdminInquiryCommentListResult,
   AdminInquiryCommentUpdateRequest,
-  AdminInquiryCommentUpdateResponse,
-  AdminInquiryDetailResponse,
-  AdminInquiryListResponse,
+  AdminInquiryCommentUpdateResult,
+  AdminInquiryDetailResult,
+  AdminInquiryListResult,
   AdminInquiryStatusUpdateRequest,
-  AdminInquiryStatusUpdateResponse,
+  AdminInquiryStatusUpdateResult,
   InquiryGroup,
   InquiryStatus,
   InquirySubGroup,
@@ -25,77 +26,69 @@ export type AdminInquiryListParams = {
 
 export const getAdminInquiriesAPI = async (
   params: AdminInquiryListParams = { page: 0 }
-): Promise<AdminInquiryListResponse> => {
-  const response = await axiosInstance.get<AdminInquiryListResponse>(
-    '/v1/admin/inquiries',
-    {
-      params,
-    }
-  );
-  return response.data;
+): Promise<AdminInquiryListResult> => {
+  const response = await axiosInstance.get<
+    BaseResponse<AdminInquiryListResult>
+  >('/v1/admin/inquiries', { params });
+  return response.data.result;
 };
 
 export const getAdminInquiryDetailAPI = async (
   inquiryId: number
-): Promise<AdminInquiryDetailResponse> => {
-  const response = await axiosInstance.get<AdminInquiryDetailResponse>(
-    `/v1/admin/inquiries/${inquiryId}`
-  );
-  return response.data;
+): Promise<AdminInquiryDetailResult> => {
+  const response = await axiosInstance.get<
+    BaseResponse<AdminInquiryDetailResult>
+  >(`/v1/admin/inquiries/${inquiryId}`);
+  return response.data.result;
 };
 
 export const updateAdminInquiryStatusAPI = async (
   inquiryId: number,
   data: AdminInquiryStatusUpdateRequest
-): Promise<AdminInquiryStatusUpdateResponse> => {
-  const response = await axiosInstance.patch<AdminInquiryStatusUpdateResponse>(
-    `/v1/admin/inquiries/${inquiryId}/status`,
-    data
-  );
-  return response.data;
+): Promise<AdminInquiryStatusUpdateResult> => {
+  const response = await axiosInstance.patch<
+    BaseResponse<AdminInquiryStatusUpdateResult>
+  >(`/v1/admin/inquiries/${inquiryId}/status`, data);
+  return response.data.result;
 };
 
 export const getAdminInquiryCommentsAPI = async (
   postId: number,
   params: { page?: number } = { page: 0 }
-): Promise<AdminInquiryCommentListResponse> => {
-  const response = await axiosInstance.get<AdminInquiryCommentListResponse>(
-    `/v1/posts/${postId}/comments`,
-    { params }
-  );
-  return response.data;
+): Promise<AdminInquiryCommentListResult> => {
+  const response = await axiosInstance.get<
+    BaseResponse<AdminInquiryCommentListResult>
+  >(`/v1/posts/${postId}/comments`, { params });
+  return response.data.result;
 };
 
 export const createInquiryCommentAPI = async (
   postId: number,
   data: AdminInquiryCommentCreateRequest
-): Promise<AdminInquiryCommentCreateResponse> => {
-  const response = await axiosInstance.post<AdminInquiryCommentCreateResponse>(
-    `/v1/posts/${postId}/comments`,
-    data
-  );
-  return response.data;
+): Promise<AdminInquiryCommentCreateResult> => {
+  const response = await axiosInstance.post<
+    BaseResponse<AdminInquiryCommentCreateResult>
+  >(`/v1/posts/${postId}/comments`, data);
+  return response.data.result;
 };
 
 export const updateInquiryCommentAPI = async (
   postId: number,
   commentId: number,
   data: AdminInquiryCommentUpdateRequest
-): Promise<AdminInquiryCommentUpdateResponse> => {
-  const response = await axiosInstance.patch<AdminInquiryCommentUpdateResponse>(
-    `/v1/posts/${postId}/comments/${commentId}`,
-    data
-  );
-  return response.data;
+): Promise<AdminInquiryCommentUpdateResult> => {
+  const response = await axiosInstance.patch<
+    BaseResponse<AdminInquiryCommentUpdateResult>
+  >(`/v1/posts/${postId}/comments/${commentId}`, data);
+  return response.data.result;
 };
 
 export const deleteInquiryCommentAPI = async (
   postId: number,
   commentId: number
-): Promise<AdminInquiryCommentDeleteResponse> => {
-  const response =
-    await axiosInstance.delete<AdminInquiryCommentDeleteResponse>(
-      `/v1/posts/${postId}/comments/${commentId}`
-    );
-  return response.data;
+): Promise<AdminInquiryCommentDeleteResult> => {
+  const response = await axiosInstance.delete<
+    BaseResponse<AdminInquiryCommentDeleteResult>
+  >(`/v1/posts/${postId}/comments/${commentId}`);
+  return response.data.result;
 };

--- a/src/apis/points.ts
+++ b/src/apis/points.ts
@@ -1,63 +1,68 @@
 import { axiosInstance } from '@/shared/axios/instance';
+import type { BaseResponse } from '@/shared/types';
 import type {
   AdjustAllMemberPoint,
   AdjustSinglePoint,
   CreatePointFreeze,
   ExcelPointBulkRewardRequest,
-  ExcelPointBulkRewardResponse,
+  ExcelPointBulkRewardResult,
+  PointFreeze,
   UpdatePointFreeze,
 } from '@/shared/types';
 
 // 어드민 포인트 증감
-export const postSinglePointAPI = async (data: AdjustSinglePoint) => {
-  const response = await axiosInstance.post('/v1/admin/points', data);
-  return response.data;
+export const postSinglePointAPI = async (
+  data: AdjustSinglePoint
+): Promise<void> => {
+  await axiosInstance.post<BaseResponse<void>>('/v1/admin/points', data);
 };
 
-export const postAllMemberPointAPI = async (data: AdjustAllMemberPoint) => {
-  const response = await axiosInstance.post(
+export const postAllMemberPointAPI = async (
+  data: AdjustAllMemberPoint
+): Promise<void> => {
+  await axiosInstance.post<BaseResponse<void>>(
     '/v1/admin/points/bulk-reward',
     data
   );
-  return response.data;
 };
 
 // 포인트 미지급 일정 관리
-export const postPointFreezeAPI = async (data: CreatePointFreeze) => {
-  const response = await axiosInstance.post(
+export const postPointFreezeAPI = async (
+  data: CreatePointFreeze
+): Promise<void> => {
+  await axiosInstance.post<BaseResponse<void>>(
     '/v1/admin/points/point-freeze',
     data
   );
-  return response.data;
 };
 
-export const getPointFreezesAPI = async () => {
-  const response = await axiosInstance.get('/v1/admin/points/point-freeze');
-  return response.data;
+export const getPointFreezesAPI = async (): Promise<PointFreeze[]> => {
+  const response = await axiosInstance.get<BaseResponse<PointFreeze[]>>(
+    '/v1/admin/points/point-freeze'
+  );
+  return response.data.result;
 };
 
 export const patchPointFreezeAPI = async (
   id: number,
   data: UpdatePointFreeze
-) => {
-  const response = await axiosInstance.patch(
+): Promise<void> => {
+  await axiosInstance.patch<BaseResponse<void>>(
     `/v1/admin/points/point-freeze/${id}`,
     data
   );
-  return response.data;
 };
 
-export const deletePointFreezeAPI = async (id: number) => {
-  const response = await axiosInstance.delete(
+export const deletePointFreezeAPI = async (id: number): Promise<void> => {
+  await axiosInstance.delete<BaseResponse<void>>(
     `/v1/admin/points/point-freeze/${id}`
   );
-  return response.data;
 };
 
 export const postExcelPointBulkRewardAPI = async (params: {
   file: File;
   request: ExcelPointBulkRewardRequest;
-}): Promise<ExcelPointBulkRewardResponse> => {
+}): Promise<ExcelPointBulkRewardResult> => {
   const formData = new FormData();
 
   formData.append(
@@ -67,15 +72,13 @@ export const postExcelPointBulkRewardAPI = async (params: {
   );
   formData.append('file', params.file);
 
-  const response = await axiosInstance.post<ExcelPointBulkRewardResponse>(
-    '/v1/admin/points/bulk-reward/excel',
-    formData,
-    {
-      headers: {
-        'Content-Type': undefined,
-      },
-    }
-  );
+  const response = await axiosInstance.post<
+    BaseResponse<ExcelPointBulkRewardResult>
+  >('/v1/admin/points/bulk-reward/excel', formData, {
+    headers: {
+      'Content-Type': undefined,
+    },
+  });
 
-  return response.data;
+  return response.data.result;
 };

--- a/src/apis/posts.ts
+++ b/src/apis/posts.ts
@@ -1,21 +1,25 @@
 import { axiosInstance } from '@/shared/axios/instance';
+import type { BaseResponse } from '@/shared/types';
 
 import type {
   AdminGetPostResponse,
-  AdminPostBulkDeleteResponse,
-  AdminPostListResponse,
+  AdminPostBulkDeleteResult,
+  AdminPostListResult,
   AdminPostSearchRequest,
-  DeletePostResponse,
 } from '@/domains/Posts/types/post';
 
 // 게시글 조건 조회 api
 export const searchPosts = async (
   page: number,
   body: AdminPostSearchRequest
-): Promise<AdminPostListResponse['result']> => {
-  const response = await axiosInstance.post('/v1/admin/posts/search', body, {
-    params: { page: page - 1 },
-  });
+): Promise<AdminPostListResult> => {
+  const response = await axiosInstance.post<BaseResponse<AdminPostListResult>>(
+    '/v1/admin/posts/search',
+    body,
+    {
+      params: { page: page - 1 },
+    }
+  );
   return response.data.result;
 };
 
@@ -23,7 +27,9 @@ export const searchPosts = async (
 export const getPost = async (
   postId: number
 ): Promise<AdminGetPostResponse> => {
-  const response = await axiosInstance.get(`/v1/admin/posts/${postId}`);
+  const response = await axiosInstance.get<BaseResponse<AdminGetPostResponse>>(
+    `/v1/admin/posts/${postId}`
+  );
   return response.data.result;
 };
 
@@ -31,23 +37,29 @@ export const getPost = async (
 export const getDeletedPost = async (
   postId: number
 ): Promise<AdminGetPostResponse> => {
-  const response = await axiosInstance.get(`/v1/admin/posts/deleted/${postId}`);
+  const response = await axiosInstance.get<BaseResponse<AdminGetPostResponse>>(
+    `/v1/admin/posts/deleted/${postId}`
+  );
   return response.data.result;
 };
 
 // 게시글 삭제 api
 export const deletePost = async (
   postId: number
-): Promise<DeletePostResponse['result']> => {
-  const response = await axiosInstance.delete(`/v1/admin/posts/${postId}`);
+): Promise<AdminGetPostResponse> => {
+  const response = await axiosInstance.delete<
+    BaseResponse<AdminGetPostResponse>
+  >(`/v1/admin/posts/${postId}`);
   return response.data.result;
 };
 
 // 여러 게시글 선택 삭제 api
 export const bulkDeletePosts = async (
   postIds: number[]
-): Promise<AdminPostBulkDeleteResponse['result']> => {
-  const response = await axiosInstance.delete('/v1/admin/posts', {
+): Promise<AdminPostBulkDeleteResult> => {
+  const response = await axiosInstance.delete<
+    BaseResponse<AdminPostBulkDeleteResult>
+  >('/v1/admin/posts', {
     data: { postIds },
   });
   return response.data.result;
@@ -58,9 +70,12 @@ export const updatePostVisibility = async (
   postIds: number[],
   isVisible: boolean
 ): Promise<string> => {
-  const response = await axiosInstance.patch(`/v1/admin/posts/visibility`, {
-    postIds,
-    isVisible,
-  });
+  const response = await axiosInstance.patch<BaseResponse<string>>(
+    `/v1/admin/posts/visibility`,
+    {
+      postIds,
+      isVisible,
+    }
+  );
   return response.data.result;
 };

--- a/src/apis/reviews.ts
+++ b/src/apis/reviews.ts
@@ -1,51 +1,52 @@
 import { axiosInstance } from '@/shared/axios/instance';
+import type { BaseResponse } from '@/shared/types';
 import type {
   CreateExamReviewPeriod,
+  ExamReviewPeriod,
   UpdateExamReviewPeriod,
 } from '@/shared/types';
 
 import type {
   ConfirmExamReviewRequest,
-  ConfirmExamReviewResponse,
-  DeleteExamReviewResponse,
-  ExamReviewDetailResponse,
+  ExamReviewDetailResult,
   ExamReviewSearchParams,
-  ExamReviewsResponse,
+  ExamReviewsResult,
   UpdateExamReviewRequest,
-  UpdateExamReviewResponse,
 } from '@/domains/Reviews/types';
 
 // 시험후기 목록 조회 api
 export const getExamReviews = async (
   params: ExamReviewSearchParams & { page: number }
-): Promise<ExamReviewsResponse> => {
-  const response = await axiosInstance.get(`/v1/admin/reviews`, {
-    params,
-  });
-  return response.data;
+): Promise<ExamReviewsResult> => {
+  const response = await axiosInstance.get<BaseResponse<ExamReviewsResult>>(
+    `/v1/admin/reviews`,
+    {
+      params,
+    }
+  );
+  return response.data.result;
 };
 
 // 시험후기 확인 처리 (isConfirmed 변경) api
 export const confirmExamReview = async (
   postId: number,
   data: ConfirmExamReviewRequest
-): Promise<ConfirmExamReviewResponse> => {
-  const response = await axiosInstance.put(
-    `/v1/admin/reviews/confirm/${postId}`,
-    data
-  );
-  return response.data;
+): Promise<{ postId: number; isConfirmed: boolean }> => {
+  const response = await axiosInstance.put<
+    BaseResponse<{ postId: number; isConfirmed: boolean }>
+  >(`/v1/admin/reviews/confirm/${postId}`, data);
+  return response.data.result;
 };
 
 // 시험후기 상세 수정 api
 export const updateExamReview = async (
   postId: number,
   data: UpdateExamReviewRequest
-): Promise<UpdateExamReviewResponse> => {
+): Promise<ExamReviewDetailResult> => {
   const formData = new FormData();
 
   if (data.file) {
-    formData.append('file', data.file); // 파일이 있으면 추가
+    formData.append('file', data.file);
   }
 
   formData.append(
@@ -53,32 +54,34 @@ export const updateExamReview = async (
     new Blob([JSON.stringify(data.post)], { type: 'application/json' })
   );
 
-  const response = await axiosInstance.patch(
-    `/v1/admin/reviews/${postId}`,
-    formData,
-    {
-      headers: {
-        'Content-Type': undefined,
-      },
-    }
-  );
-  return response.data;
+  const response = await axiosInstance.patch<
+    BaseResponse<ExamReviewDetailResult>
+  >(`/v1/admin/reviews/${postId}`, formData, {
+    headers: {
+      'Content-Type': undefined,
+    },
+  });
+  return response.data.result;
 };
 
 // 시험후기 삭제 api
 export const deleteExamReview = async (
   postId: number
-): Promise<DeleteExamReviewResponse> => {
-  const response = await axiosInstance.delete(`/v1/admin/reviews/${postId}`);
-  return response.data;
+): Promise<{ postId: number }> => {
+  const response = await axiosInstance.delete<BaseResponse<{ postId: number }>>(
+    `/v1/admin/reviews/${postId}`
+  );
+  return response.data.result;
 };
 
 // 시험후기 상세 조회 api
 export const getExamReviewDetail = async (
   postId: number
-): Promise<ExamReviewDetailResponse> => {
-  const response = await axiosInstance.get(`/v1/admin/reviews/${postId}`);
-  return response.data;
+): Promise<ExamReviewDetailResult> => {
+  const response = await axiosInstance.get<
+    BaseResponse<ExamReviewDetailResult>
+  >(`/v1/admin/reviews/${postId}`);
+  return response.data.result;
 };
 
 // 시험후기 파일 다운로드 api
@@ -88,38 +91,44 @@ export const downloadExamReviewFile = async (
 ): Promise<Blob> => {
   const response = await axiosInstance.get(
     `/v1/reviews/files/${postId}/download/${fileName}`,
-    {
-      responseType: 'blob',
-    }
+    { responseType: 'blob' }
   );
   return response.data;
 };
 
 // 시험 후기 작성 기간 관리 api
-export const postExamReviewPeriodAPI = async (data: CreateExamReviewPeriod) => {
-  const response = await axiosInstance.post('/v1/admin/reviews/period', data);
-  return response.data;
+export const postExamReviewPeriodAPI = async (
+  data: CreateExamReviewPeriod
+): Promise<void> => {
+  await axiosInstance.post<BaseResponse<void>>(
+    '/v1/admin/reviews/period',
+    data
+  );
 };
 
-export const getExamReviewPeriodsAPI = async () => {
-  const response = await axiosInstance.get('/v1/admin/reviews/period');
-  return response.data;
+export const getExamReviewPeriodsAPI = async (): Promise<
+  ExamReviewPeriod[]
+> => {
+  const response = await axiosInstance.get<BaseResponse<ExamReviewPeriod[]>>(
+    '/v1/admin/reviews/period'
+  );
+  return response.data.result;
 };
 
 export const patchExamReviewPeriodAPI = async (
   periodId: number,
   data: UpdateExamReviewPeriod
-) => {
-  const response = await axiosInstance.patch(
+): Promise<void> => {
+  await axiosInstance.patch<BaseResponse<void>>(
     `/v1/admin/reviews/period/${periodId}`,
     data
   );
-  return response.data;
 };
 
-export const deleteExamReviewPeriodAPI = async (periodId: number) => {
-  const response = await axiosInstance.delete(
+export const deleteExamReviewPeriodAPI = async (
+  periodId: number
+): Promise<void> => {
+  await axiosInstance.delete<BaseResponse<void>>(
     `/v1/admin/reviews/period/${periodId}`
   );
-  return response.data;
 };

--- a/src/apis/users.ts
+++ b/src/apis/users.ts
@@ -1,42 +1,47 @@
 import { axiosInstance } from '@/shared/axios/instance';
+import type { BaseResponse } from '@/shared/types';
 import type {
-  AdminUserListResponse,
+  AdminUserListResult,
   EditMemberInfo,
   MemberInfo,
-  UpdateUserInfoResponse,
 } from '@/shared/types';
 
 export const getAllUsersAPI = async (
   page: number = 0
-): Promise<AdminUserListResponse> => {
-  const response = await axiosInstance.get(`/v1/admin/users`, {
-    params: { page },
-  });
+): Promise<AdminUserListResult> => {
+  const response = await axiosInstance.get<BaseResponse<AdminUserListResult>>(
+    `/v1/admin/users`,
+    {
+      params: { page },
+    }
+  );
   return response.data.result;
 };
 
-export const searchUsersAPI = async (keyword: string) => {
-  const response = await axiosInstance.get(`/v1/admin/users/search`, {
-    params: { keyword },
-  });
-  return response.data;
+export const searchUsersAPI = async (keyword: string): Promise<MemberInfo> => {
+  const response = await axiosInstance.get<BaseResponse<MemberInfo>>(
+    `/v1/admin/users/search`,
+    {
+      params: { keyword },
+    }
+  );
+  return response.data.result;
 };
 
 export const editUsersAPI = async (
   encryptedUserId: string,
   data: Partial<EditMemberInfo>
-): Promise<UpdateUserInfoResponse> => {
-  const response = await axiosInstance.patch(
+): Promise<void> => {
+  await axiosInstance.patch<BaseResponse<void>>(
     `/v1/admin/users/${encryptedUserId}`,
     data
   );
-  return response.data;
 };
 
 export const getUserDetailAPI = async (
   encryptedUserId: string
 ): Promise<MemberInfo> => {
-  const response = await axiosInstance.get(
+  const response = await axiosInstance.get<BaseResponse<MemberInfo>>(
     `/v1/admin/users/${encryptedUserId}`
   );
   return response.data.result;

--- a/src/domains/Comments/components/CommentTableRow.tsx
+++ b/src/domains/Comments/components/CommentTableRow.tsx
@@ -7,7 +7,7 @@ import { Badge, Table } from '@/shared/components/ui';
 import { cn } from '@/shared/lib';
 import { formatDateTimeWithAmPm } from '@/shared/utils';
 
-import type { AdminCommentResponse } from '../types/comment';
+import type { AdminCommentResult } from '../types/comment';
 import {
   BOARD_NAMES,
   formatCommentId,
@@ -16,10 +16,10 @@ import {
 } from '../utils/commentUtils';
 
 interface CommentTableRowProps {
-  comment: AdminCommentResponse;
+  comment: AdminCommentResult;
   isSelected: boolean;
   onSelectToggle: (id: number) => void;
-  onSingleVisibilityToggle: (comment: AdminCommentResponse) => void;
+  onSingleVisibilityToggle: (comment: AdminCommentResult) => void;
   onFilterByPostId: (postId: number) => void;
   onFilterByParentId: (parentId: number) => void;
 }

--- a/src/domains/Comments/hooks/useCommentTableState.ts
+++ b/src/domains/Comments/hooks/useCommentTableState.ts
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 
 import type { CommentSearchParams } from '../types';
-import type { AdminCommentResponse } from '../types/comment';
+import type { AdminCommentResult } from '../types/comment';
 import { useBulkDeleteComment } from './useBulkDeleteComment';
 import { useCommentList } from './useCommentList';
 import { useUpdateCommentVisibility } from './useUpdateCommentVisibility';
@@ -34,7 +34,7 @@ export function useCommentTableState({
     if (refreshKey) void refetch();
   }, [refreshKey, refetch]);
 
-  const comments = useMemo<AdminCommentResponse[]>(
+  const comments = useMemo<AdminCommentResult[]>(
     () => data?.data ?? [],
     [data]
   );
@@ -141,7 +141,7 @@ export function useCommentTableState({
   };
 
   // 비공개 해제 / 삭제 복구 단건 토글 액션
-  const handleSingleVisibility = (comment: AdminCommentResponse) => {
+  const handleSingleVisibility = (comment: AdminCommentResult) => {
     const isCurrentlyVisible = comment.isVisible;
     bulkVisibility(
       { commentIds: [comment.commentId], isVisible: !isCurrentlyVisible },

--- a/src/domains/Comments/types/comment.ts
+++ b/src/domains/Comments/types/comment.ts
@@ -1,6 +1,6 @@
 import type { AdminStatus } from '@/shared/utils/postCommentUtils';
 
-export interface AdminCommentResponse {
+export interface AdminCommentResult {
   encryptedUserId: string;
   boardId: number;
   boardName?: string;
@@ -39,14 +39,14 @@ export interface AdminCommentSearchRequest {
   adminCommonStatuses?: AdminStatus[];
 }
 
-export interface AdminCommentListResponse {
+export interface AdminCommentListResult {
   hasNext: boolean;
   totalPage?: number;
   totalCount?: number;
-  data: AdminCommentResponse[];
+  data: AdminCommentResult[];
 }
 
-export interface AdminDeleteCommentResponse {
+export interface AdminDeleteCommentResult {
   id: number;
   encryptedUserId: string;
   postId: number;
@@ -57,7 +57,7 @@ export interface AdminCommentBulkDeleteRequest {
   commentIds: number[];
 }
 
-export interface AdminCommentBulkDeleteResponse {
+export interface AdminCommentBulkDeleteResult {
   requestedCount: number;
   deletedCount: number;
   failedCount: number;

--- a/src/domains/InquiryReport/components/InquiryReportDetailPanel.tsx
+++ b/src/domains/InquiryReport/components/InquiryReportDetailPanel.tsx
@@ -60,8 +60,8 @@ export default function InquiryReportDetailPanel({
   const updateComment = useUpdateInquiryComment(postId);
   const deleteComment = useDeleteInquiryComment(postId);
 
-  const detail = detailData?.result;
-  const comments = commentsData?.result.data ?? [];
+  const detail = detailData;
+  const comments = commentsData?.data ?? [];
 
   useEffect(() => {
     setCommentInput('');

--- a/src/domains/InquiryReport/hooks/useCreateInquiryComment.ts
+++ b/src/domains/InquiryReport/hooks/useCreateInquiryComment.ts
@@ -20,12 +20,10 @@ export const useCreateInquiryComment = (postId: number) => {
         );
       }
 
-      const response = await createInquiryCommentAPI(postId, {
+      return await createInquiryCommentAPI(postId, {
         ...data,
         content,
       });
-      if (!response.isSuccess) throw new Error(response.message);
-      return response;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['inquiryComments', postId] });

--- a/src/domains/InquiryReport/hooks/useDeleteInquiryComment.ts
+++ b/src/domains/InquiryReport/hooks/useDeleteInquiryComment.ts
@@ -8,9 +8,7 @@ export const useDeleteInquiryComment = (postId: number) => {
 
   return useMutation({
     mutationFn: async (commentId: number) => {
-      const response = await deleteInquiryCommentAPI(postId, commentId);
-      if (!response.isSuccess) throw new Error(response.message);
-      return response;
+      return await deleteInquiryCommentAPI(postId, commentId);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['inquiryComments', postId] });

--- a/src/domains/InquiryReport/hooks/useInquiryComments.ts
+++ b/src/domains/InquiryReport/hooks/useInquiryComments.ts
@@ -7,7 +7,6 @@ export const useInquiryComments = (postId: number | null) => {
     queryKey: ['inquiryComments', postId],
     queryFn: async () => {
       const response = await getAdminInquiryCommentsAPI(postId!);
-      if (!response.isSuccess) throw new Error(response.message);
       return response;
     },
     enabled: postId !== null,

--- a/src/domains/InquiryReport/hooks/useInquiryDetail.ts
+++ b/src/domains/InquiryReport/hooks/useInquiryDetail.ts
@@ -7,7 +7,6 @@ export const useInquiryDetail = (postId: number | null) => {
     queryKey: ['inquiryDetail', postId],
     queryFn: async () => {
       const response = await getAdminInquiryDetailAPI(postId!);
-      if (!response.isSuccess) throw new Error(response.message);
       return response;
     },
     enabled: postId !== null,

--- a/src/domains/InquiryReport/hooks/useInquiryList.ts
+++ b/src/domains/InquiryReport/hooks/useInquiryList.ts
@@ -16,9 +16,8 @@ export const useInquiryList = () => {
 
       while (hasNext && page < MAX_INQUIRY_LIST_PAGE_REQUESTS) {
         const response = await getAdminInquiriesAPI({ page });
-        if (!response.isSuccess) throw new Error(response.message);
-        allData.push(...response.result.data);
-        hasNext = response.result.hasNext;
+        allData.push(...response.data);
+        hasNext = response.hasNext;
         page += 1;
       }
 

--- a/src/domains/InquiryReport/hooks/useUpdateInquiryComment.ts
+++ b/src/domains/InquiryReport/hooks/useUpdateInquiryComment.ts
@@ -24,11 +24,9 @@ export const useUpdateInquiryComment = (postId: number) => {
         );
       }
 
-      const response = await updateInquiryCommentAPI(postId, commentId, {
+      return await updateInquiryCommentAPI(postId, commentId, {
         content: trimmedContent,
       });
-      if (!response.isSuccess) throw new Error(response.message);
-      return response;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['inquiryComments', postId] });

--- a/src/domains/InquiryReport/hooks/useUpdateInquiryStatus.ts
+++ b/src/domains/InquiryReport/hooks/useUpdateInquiryStatus.ts
@@ -16,9 +16,7 @@ export const useUpdateInquiryStatus = () => {
       inquiryId: number;
       status: InquiryStatus;
     }) => {
-      const response = await updateAdminInquiryStatusAPI(inquiryId, { status });
-      if (!response.isSuccess) throw new Error(response.message);
-      return response;
+      return await updateAdminInquiryStatusAPI(inquiryId, { status });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['inquiries'] });

--- a/src/domains/MemberInfo/components/BlacklistHistoryTab.tsx
+++ b/src/domains/MemberInfo/components/BlacklistHistoryTab.tsx
@@ -45,9 +45,9 @@ export default function BlacklistHistoryTab({
         setCurrentPage(1);
         const data = await blacklistHistoryAPI(encryptedUserId);
 
-        if (data?.result?.data) {
+        if (data?.data) {
           setHistoryData(
-            data.result.data.map((history) =>
+            data.data.map((history) =>
               toBlacklistHistoryItem(history, {
                 encryptedUserId,
                 studentNumber,

--- a/src/domains/MemberInfo/hooks/useMemberDetailState.ts
+++ b/src/domains/MemberInfo/hooks/useMemberDetailState.ts
@@ -58,7 +58,7 @@ export function useMemberDetailState({
       if (!keyword.trim()) continue;
       try {
         const response = await searchUsersAPI(keyword);
-        const resolvedMember = extractFirstSearchMember(response?.result);
+        const resolvedMember = extractFirstSearchMember(response);
         if (resolvedMember) return resolvedMember;
       } catch (error) {
         latestError = error;
@@ -88,7 +88,7 @@ export function useMemberDetailState({
       const response = await blacklistHistoryAPI(encryptedUserId, {
         page,
       });
-      const history = response.result.data.map((item) =>
+      const history = response.data.map((item) =>
         toBlacklistHistoryItem(item, {
           encryptedUserId,
           studentNumber,
@@ -201,8 +201,8 @@ export function useMemberDetailState({
         setPenaltyHistory(history);
         setLatestPenaltyHistory(resolveLatestPenaltyHistory(history));
         setPenaltyHistoryPage(0);
-        setHasNextPenaltyHistory(response.result.hasNext);
-        setPenaltyHistoryTotalCount(response.result.totalCount);
+        setHasNextPenaltyHistory(response.hasNext);
+        setPenaltyHistoryTotalCount(response.totalCount);
       } catch (error) {
         if (!isMounted) return;
         toast.error(getErrorMessage(error, '제재 이력 조회에 실패했습니다.'));
@@ -242,8 +242,8 @@ export function useMemberDetailState({
 
       setPenaltyHistory((prev) => [...prev, ...nextHistory]);
       setPenaltyHistoryPage(nextPage);
-      setHasNextPenaltyHistory(response.result.hasNext);
-      setPenaltyHistoryTotalCount(response.result.totalCount);
+      setHasNextPenaltyHistory(response.hasNext);
+      setPenaltyHistoryTotalCount(response.totalCount);
     } catch (error) {
       toast.error(
         getErrorMessage(error, '다음 제재 이력을 불러오지 못했습니다.')
@@ -272,8 +272,8 @@ export function useMemberDetailState({
       setPenaltyHistory(history);
       setLatestPenaltyHistory(resolveLatestPenaltyHistory(history));
       setPenaltyHistoryPage(0);
-      setHasNextPenaltyHistory(response.result.hasNext);
-      setPenaltyHistoryTotalCount(response.result.totalCount);
+      setHasNextPenaltyHistory(response.hasNext);
+      setPenaltyHistoryTotalCount(response.totalCount);
     } catch (error) {
       toast.error(
         getErrorMessage(error, '제재 이력을 다시 불러오지 못했습니다.')
@@ -294,15 +294,7 @@ export function useMemberDetailState({
           return;
         }
 
-        const editResponse = await editUsersAPI(
-          selectedMember.encryptedUserId,
-          diffPayload
-        );
-        if (!editResponse?.isSuccess || editResponse.code !== 1000) {
-          throw new Error(
-            editResponse?.message || '회원 정보 수정에 실패했습니다.'
-          );
-        }
+        await editUsersAPI(selectedMember.encryptedUserId, diffPayload);
 
         const nextSelectedMember = { ...selectedMember, ...updated };
         setSelectedMember(nextSelectedMember);

--- a/src/domains/MemberInfo/hooks/useMemberDirectoryState.ts
+++ b/src/domains/MemberInfo/hooks/useMemberDirectoryState.ts
@@ -108,7 +108,7 @@ export function useMemberDirectoryState(isDetailRoute: boolean) {
     setIsSearching(true);
     try {
       const response = await searchUsersAPI(searchQuery.trim());
-      const resultMembers = normalizeSearchResultMembers(response?.result);
+      const resultMembers = normalizeSearchResultMembers(response);
       if (resultMembers.length === 0) {
         toast.error('회원 검색 결과가 없습니다.');
         return;

--- a/src/domains/Posts/components/PostDetail/PostDetailCommentItem.tsx
+++ b/src/domains/Posts/components/PostDetail/PostDetailCommentItem.tsx
@@ -14,13 +14,13 @@ import { MemberInfoPopover } from '@/shared/components';
 import { Badge, Button } from '@/shared/components/ui';
 import { formatDateTimeWithAmPm } from '@/shared/utils';
 
-import type { AdminCommentResponse } from '@/domains/Comments/types';
+import type { AdminCommentResult } from '@/domains/Comments/types';
 import { getPostStatusBadges } from '@/domains/Comments/utils/commentUtils';
 
 import { deleteComment, updateCommentVisibility } from '@/apis';
 
 interface PostDetailCommentItemProps {
-  comment: AdminCommentResponse;
+  comment: AdminCommentResult;
 }
 
 export default function PostDetailCommentItem({

--- a/src/domains/Posts/types/post.ts
+++ b/src/domains/Posts/types/post.ts
@@ -19,16 +19,11 @@ export interface AdminGetPostResponse {
   createdAt: string;
 }
 
-export interface AdminPostListResponse {
-  isSuccess: boolean;
-  code: number;
-  message: string;
-  result: {
-    hasNext: boolean;
-    totalPage?: number;
-    totalCount?: number;
-    data: AdminGetPostResponse[];
-  };
+export interface AdminPostListResult {
+  hasNext: boolean;
+  totalPage?: number;
+  totalCount?: number;
+  data: AdminGetPostResponse[];
 }
 
 export interface AdminPostSearchRequest {
@@ -56,31 +51,19 @@ export interface AdminPostSearchRequest {
   content?: string;
 }
 
-export interface DeletePostResponse {
-  isSuccess: boolean;
-  code: number;
-  message: string;
-  result: AdminGetPostResponse;
-}
-
 export interface AdminPostBulkDeleteRequest {
   postIds: number[];
 }
 
-export interface AdminPostBulkDeleteResponse {
-  isSuccess: boolean;
-  code: number;
-  message: string;
-  result: {
-    requestedCount: number;
-    deletedCount: number;
-    failedCount: number;
-    deletedPostIds: number[];
-    notDeletedPosts: {
-      postId: number;
-      reason: string;
-    }[];
-  };
+export interface AdminPostBulkDeleteResult {
+  requestedCount: number;
+  deletedCount: number;
+  failedCount: number;
+  deletedPostIds: number[];
+  notDeletedPosts: {
+    postId: number;
+    reason: string;
+  }[];
 }
 
 export interface PostSearchParams {

--- a/src/domains/Reviews/components/ExamDetailSection.tsx
+++ b/src/domains/Reviews/components/ExamDetailSection.tsx
@@ -442,33 +442,21 @@ export function ExamDetailSection({
           post,
         };
 
-        const response = await updateExamReview(
+        updatedDetail = await updateExamReview(
           selectedExamReview.id,
           updateData
         );
-
-        if (!response.isSuccess) {
-          toast.error(response.message || '시험 후기 수정에 실패했습니다.');
-          return;
-        }
-
-        updatedDetail = response.result;
       }
 
       if (hasConfirmUpdate) {
-        const response = await confirmExamReview(selectedExamReview.id, {
+        const confirmResult = await confirmExamReview(selectedExamReview.id, {
           isConfirmed: formData.isConfirmed,
         });
 
-        if (!response.isSuccess) {
-          toast.error(response.message || '시험 후기 확인처리에 실패했습니다.');
-          return;
-        }
-
         updatedDetail = {
           ...updatedDetail,
-          isConfirmed: response.result.isConfirmed,
-          status: response.result.isConfirmed ? 'CONFIRMED' : 'UNCONFIRMED',
+          isConfirmed: confirmResult.isConfirmed,
+          status: confirmResult.isConfirmed ? 'CONFIRMED' : 'UNCONFIRMED',
         };
       }
 
@@ -507,15 +495,11 @@ export function ExamDetailSection({
         toast.error('선택된 시험 후기가 없습니다.');
         return;
       }
-      const response = await deleteExamReview(selectedExamReview.id);
-      if (response.isSuccess) {
-        toast.success('시험 후기가 성공적으로 삭제되었습니다.');
-        setIsDeleteModalOpen(false);
-        resetForm();
-        onDeleteSuccess?.();
-      } else {
-        toast.error(response.message || '시험 후기 삭제에 실패했습니다.');
-      }
+      await deleteExamReview(selectedExamReview.id);
+      toast.success('시험 후기가 성공적으로 삭제되었습니다.');
+      setIsDeleteModalOpen(false);
+      resetForm();
+      onDeleteSuccess?.();
     } catch (error: unknown) {
       const errorMessage =
         (isAxiosError(error) && error.response?.data?.message) ||

--- a/src/domains/Reviews/components/ExamReviewCommentSection.tsx
+++ b/src/domains/Reviews/components/ExamReviewCommentSection.tsx
@@ -5,7 +5,7 @@ import { Loader2 } from 'lucide-react';
 
 import { formatDateTimeToMinutes } from '@/shared/utils';
 
-import { type PostCommentResponse, getPostCommentsAPI } from '@/apis';
+import { type PostCommentResult, getPostCommentsAPI } from '@/apis';
 
 interface ExamReviewCommentSectionProps {
   postId: number | null;
@@ -21,13 +21,7 @@ export function ExamReviewCommentSection({
     enabled: Boolean(postId),
     initialPageParam: 0,
     queryFn: async ({ pageParam }) => {
-      const response = await getPostCommentsAPI(postId!, pageParam);
-
-      if (!response.isSuccess || !response.result) {
-        throw new Error(response.message || '댓글 목록을 불러오지 못했습니다.');
-      }
-
-      return response.result;
+      return await getPostCommentsAPI(postId!, pageParam);
     },
     getNextPageParam: (lastPage, allPages) => {
       if (!lastPage.hasNext) return undefined;
@@ -66,10 +60,7 @@ export function ExamReviewCommentSection({
 
   if (!postId) return null;
 
-  const renderComment = (
-    comment: PostCommentResponse,
-    depth = 0
-  ): ReactNode => {
+  const renderComment = (comment: PostCommentResult, depth = 0): ReactNode => {
     return (
       <div key={comment.id} className='flex flex-col gap-2'>
         <article
@@ -91,7 +82,9 @@ export function ExamReviewCommentSection({
 
         {comment.children?.length > 0 && (
           <div className='flex flex-col gap-2'>
-            {comment.children.map((child) => renderComment(child, depth + 1))}
+            {comment.children.map((child: PostCommentResult) =>
+              renderComment(child, depth + 1)
+            )}
           </div>
         )}
       </div>

--- a/src/domains/Reviews/hooks/use-exam-reviews.ts
+++ b/src/domains/Reviews/hooks/use-exam-reviews.ts
@@ -120,17 +120,11 @@ export const useExamReviews = (params: UseExamReviewsParams) => {
         statuses,
       });
 
-      if (!response.isSuccess || !response.result) {
-        throw new Error(
-          response.message || '시험 후기 목록을 불러오는데 실패했습니다.'
-        );
-      }
-
       return {
-        data: response.result.data.map(transformApiResponseToExamReview),
-        hasNext: response.result.hasNext,
-        totalPage: response.result.totalPage,
-        totalCount: response.result.totalCount,
+        data: response.data.map(transformApiResponseToExamReview),
+        hasNext: response.hasNext,
+        totalPage: response.totalPage,
+        totalCount: response.totalCount,
       };
     },
     enabled,

--- a/src/domains/Reviews/types/exam.ts
+++ b/src/domains/Reviews/types/exam.ts
@@ -94,16 +94,6 @@ export interface ConfirmExamReviewRequest {
   isConfirmed: boolean;
 }
 
-export interface ConfirmExamReviewResponse {
-  isSuccess: boolean;
-  code: number;
-  message: string;
-  result: {
-    postId: number;
-    isConfirmed: boolean;
-  };
-}
-
 export interface UpdateExamReviewPost {
   isConfirmed?: boolean;
   isDiscussed?: boolean;
@@ -124,22 +114,6 @@ export interface UpdateExamReviewPost {
 export interface UpdateExamReviewRequest {
   file?: File;
   post: UpdateExamReviewPost;
-}
-
-export interface UpdateExamReviewResponse {
-  isSuccess: boolean;
-  code: number;
-  message: string;
-  result: ExamReviewDetailResult;
-}
-
-export interface DeleteExamReviewResponse {
-  isSuccess: boolean;
-  code: number;
-  message: string;
-  result: {
-    postId: number;
-  };
 }
 
 export interface ExamReviewDetailLog {
@@ -177,21 +151,9 @@ export interface ExamReviewDetailResult {
   logs: ExamReviewDetailLog[] | null;
 }
 
-export interface ExamReviewDetailResponse {
-  isSuccess: boolean;
-  code: number;
-  message: string;
-  result: ExamReviewDetailResult;
-}
-
-export interface ExamReviewsResponse {
-  isSuccess: boolean;
-  code: number;
-  message: string;
-  result: {
-    data: ExamReviews[];
-    hasNext: boolean;
-    totalPage?: number;
-    totalCount?: number;
-  };
+export interface ExamReviewsResult {
+  data: ExamReviews[];
+  hasNext: boolean;
+  totalPage?: number;
+  totalCount?: number;
 }

--- a/src/domains/Reviews/types/index.ts
+++ b/src/domains/Reviews/types/index.ts
@@ -1,22 +1,18 @@
 export type {
   ConfirmExamReviewRequest,
-  ConfirmExamReviewResponse,
-  DeleteExamReviewResponse,
   ExamReview,
   ExamReviewDetailLog,
-  ExamReviewDetailResponse,
   ExamReviewDetailResult,
   ExamReviewProcessStatus,
   ExamReviews,
   ExamReviewSearchParams,
   ExamReviewSort,
-  ExamReviewsResponse,
+  ExamReviewsResult,
   ExamType,
   LectureType,
   Semester,
   Status,
   UpdateExamReviewPost,
   UpdateExamReviewRequest,
-  UpdateExamReviewResponse,
 } from './exam';
 export { EXAM_REVIEW_SORTS, isExamReviewSort } from './exam';

--- a/src/pages/alerts/PushNotificationPage.test.tsx
+++ b/src/pages/alerts/PushNotificationPage.test.tsx
@@ -327,7 +327,7 @@ describe('PushNotificationPage', () => {
   });
 
   test('모달에서 확인 버튼을 클릭하면 API가 호출되고 성공 토스트가 표시된다', async () => {
-    vi.mocked(postPushNotificationAPI).mockResolvedValue({});
+    vi.mocked(postPushNotificationAPI).mockResolvedValue(undefined);
     const user = userEvent.setup();
     render(<PushNotificationPage />);
 
@@ -366,7 +366,7 @@ describe('PushNotificationPage', () => {
   });
 
   test('API 호출 성공 시 폼이 초기화된다', async () => {
-    vi.mocked(postPushNotificationAPI).mockResolvedValue({});
+    vi.mocked(postPushNotificationAPI).mockResolvedValue(undefined);
     const user = userEvent.setup();
     render(<PushNotificationPage />);
 
@@ -419,7 +419,7 @@ describe('PushNotificationPage', () => {
   });
 
   test('모달에서 확인 버튼 클릭 시 올바른 데이터가 전달된다', async () => {
-    vi.mocked(postPushNotificationAPI).mockResolvedValue({});
+    vi.mocked(postPushNotificationAPI).mockResolvedValue(undefined);
     const user = userEvent.setup();
     render(<PushNotificationPage />);
 
@@ -592,7 +592,7 @@ describe('PushNotificationPage', () => {
     });
 
     test('URL에 특수 문자가 포함되어도 알림 전송이 가능해야 한다', async () => {
-      vi.mocked(postPushNotificationAPI).mockResolvedValue({});
+      vi.mocked(postPushNotificationAPI).mockResolvedValue(undefined);
       const user = userEvent.setup();
       render(<PushNotificationPage />);
 
@@ -669,8 +669,8 @@ describe('PushNotificationPage', () => {
     });
 
     test('API 호출 중에 다시 확인 버튼을 클릭해도 중복 호출되지 않아야 한다', async () => {
-      let resolvePromise: (value: unknown) => void;
-      const promise = new Promise((resolve) => {
+      let resolvePromise: (value: void) => void;
+      const promise = new Promise<void>((resolve) => {
         resolvePromise = resolve;
       });
       vi.mocked(postPushNotificationAPI).mockReturnValue(promise);
@@ -699,7 +699,7 @@ describe('PushNotificationPage', () => {
       expect(postPushNotificationAPI).toHaveBeenCalledTimes(1);
 
       // Promise 해결
-      resolvePromise!({});
+      resolvePromise!(undefined);
       await promise;
     });
 
@@ -741,7 +741,7 @@ describe('PushNotificationPage', () => {
     );
 
     test('외부 URL 모드에서 스노로즈 전체(https) 주소를 입력하면 모달이 열리고 API 호출 시 그대로 전달된다', async () => {
-      vi.mocked(postPushNotificationAPI).mockResolvedValue({});
+      vi.mocked(postPushNotificationAPI).mockResolvedValue(undefined);
       const user = userEvent.setup();
       render(<PushNotificationPage />);
 
@@ -783,7 +783,7 @@ describe('PushNotificationPage', () => {
     });
 
     test('외부 URL 모드에서 스노로즈 전체(http) 주소를 입력하면 모달이 열리고 API 호출 시 그대로 전달된다', async () => {
-      vi.mocked(postPushNotificationAPI).mockResolvedValue({});
+      vi.mocked(postPushNotificationAPI).mockResolvedValue(undefined);
       const user = userEvent.setup();
       render(<PushNotificationPage />);
 
@@ -895,7 +895,7 @@ describe('PushNotificationPage', () => {
     });
 
     test('URL이 빈 문자열일 때 API 호출 시 절대 경로로 전달된다', async () => {
-      vi.mocked(postPushNotificationAPI).mockResolvedValue({});
+      vi.mocked(postPushNotificationAPI).mockResolvedValue(undefined);
       const user = userEvent.setup();
       render(<PushNotificationPage />);
 

--- a/src/pages/member/MemberPenaltyManagementPage.tsx
+++ b/src/pages/member/MemberPenaltyManagementPage.tsx
@@ -36,10 +36,10 @@ export default function MemberPenaltyManagementPage() {
     }
 
     try {
-      const data = await searchUsersAPI(query);
+      const member = await searchUsersAPI(query);
 
-      if (data?.result) {
-        setSelectedMember(data.result);
+      if (member) {
+        setSelectedMember(member);
         setErrorMessage('');
         return;
       }

--- a/src/pages/points/AdjustSinglePointPage.tsx
+++ b/src/pages/points/AdjustSinglePointPage.tsx
@@ -36,8 +36,8 @@ export default function AdjustSinglePointPage() {
 
     setIsSearching(true);
     try {
-      const data = await searchUsersAPI(searchQuery.trim());
-      setSearchedMember(data.result);
+      const member = await searchUsersAPI(searchQuery.trim());
+      setSearchedMember(member);
     } catch (error: unknown) {
       toast.error(getErrorMessage(error, '회원 검색에 실패했습니다.'));
       setSearchedMember(null);

--- a/src/pages/points/ExcelPointUploadPage.tsx
+++ b/src/pages/points/ExcelPointUploadPage.tsx
@@ -370,7 +370,7 @@ export default function ExcelPointUploadPage() {
         uploadedFile.name
       );
 
-      const response = await postExcelPointBulkRewardAPI({
+      const result = await postExcelPointBulkRewardAPI({
         file: submitFile,
         request: {
           paymentMethod:
@@ -382,15 +382,8 @@ export default function ExcelPointUploadPage() {
         },
       });
 
-      if (!response.isSuccess || !response.result) {
-        toast.error(response.message || '처리에 실패했습니다.');
-        return;
-      }
-
-      setUploadResult(
-        remapUploadResultRowNumbers(response.result, submittedRows)
-      );
-      toast.success(response.message || '처리가 완료되었습니다.');
+      setUploadResult(remapUploadResultRowNumbers(result, submittedRows));
+      toast.success('처리가 완료되었습니다.');
     } catch (error: unknown) {
       toast.error(getErrorMessage(error, '엑셀 업로드 처리에 실패했습니다.'));
     } finally {

--- a/src/pages/points/PointFreezePage.tsx
+++ b/src/pages/points/PointFreezePage.tsx
@@ -25,7 +25,7 @@ export default function PointFreezePage() {
 
     try {
       const data = await getPointFreezesAPI();
-      setPointFreezes(data.result as PointFreeze[]);
+      setPointFreezes(data);
     } catch (error: unknown) {
       toast.error(getErrorMessage(error, '미지급 일정 조회에 실패했습니다.'));
     } finally {

--- a/src/pages/reviews/ExamReviewPage.tsx
+++ b/src/pages/reviews/ExamReviewPage.tsx
@@ -222,16 +222,7 @@ export default function ExamReviewPage() {
         if (updatedDetailFromSave !== undefined) {
           updatedDetail = updatedDetailFromSave;
         } else {
-          const response = await getExamReviewDetail(selectedExamReview.id);
-
-          if (!response.isSuccess || !response.result) {
-            throw new Error(
-              response.message ||
-                '시험 후기 상세 정보를 불러오는데 실패했습니다.'
-            );
-          }
-
-          updatedDetail = response.result;
+          updatedDetail = await getExamReviewDetail(selectedExamReview.id);
         }
 
         // 현재 검색 파라미터로 쿼리 키 생성
@@ -343,15 +334,7 @@ export default function ExamReviewPage() {
 
         // 요청이 완료되었을 때 현재 선택된 ID와 일치하는지 확인
         if (fetchingIdRef.current === examId) {
-          if (response.isSuccess && response.result) {
-            setSelectedExamReviewDetail(response.result);
-          } else {
-            toast.error(
-              response.message ||
-                '시험 후기 상세 정보를 불러오는데 실패했습니다.'
-            );
-            setSelectedExamReviewDetail(null);
-          }
+          setSelectedExamReviewDetail(response);
         }
       } catch (error: unknown) {
         // 요청이 완료되었을 때 현재 선택된 ID와 일치하는지 확인

--- a/src/pages/reviews/ExamReviewPeriodPage.tsx
+++ b/src/pages/reviews/ExamReviewPeriodPage.tsx
@@ -27,7 +27,7 @@ export default function ExamReviewPeriodPage() {
 
     try {
       const data = await getExamReviewPeriodsAPI();
-      setExamReviewPeriods(data.result as ExamReviewPeriod[]);
+      setExamReviewPeriods(data);
     } catch (error: unknown) {
       toast.error(
         getErrorMessage(error, '시험 후기 작성 기간 조회에 실패했습니다.')

--- a/src/shared/contexts/AuthProvider.tsx
+++ b/src/shared/contexts/AuthProvider.tsx
@@ -1,32 +1,31 @@
 import {
-  useState,
-  useEffect,
-  useCallback,
-  useRef,
-  type ReactNode,
   type JSX,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
 } from 'react';
 import { useNavigate } from 'react-router-dom';
+
 import { isAxiosError } from 'axios';
-import { AuthContext } from './AuthContext';
-import type {
-  User,
-  LoginRequest,
-  AuthContextType,
-  ApiErrorResponse,
-} from '@/shared/types';
-import {
-  tokenStorage,
-  TokenRefreshManager,
-  executeTokenRefresh,
-  userStorage,
-} from '@/shared/utils';
+
 import {
   ACCESS_TOKEN_EXPIRE_MINUTES,
-  REFRESH_TOKEN_EXPIRE_DAYS,
   ADMIN_ROLE_ID,
+  REFRESH_TOKEN_EXPIRE_DAYS,
 } from '@/shared/constants';
+import type { AuthContextType, LoginRequest, User } from '@/shared/types';
+import {
+  TokenRefreshManager,
+  executeTokenRefresh,
+  tokenStorage,
+  userStorage,
+} from '@/shared/utils';
+
 import { loginAPI } from '@/apis';
+
+import { AuthContext } from './AuthContext';
 
 type AuthProviderProps = {
   children: ReactNode;
@@ -141,7 +140,7 @@ export const AuthProvider = ({ children }: AuthProviderProps): JSX.Element => {
         }
       } catch (error: unknown) {
         const errorMessage =
-          (isAxiosError<ApiErrorResponse>(error) &&
+          (isAxiosError<{ message?: string }>(error) &&
             error.response?.data?.message) ||
           '서버와 연결할 수 없습니다. 잠시 후 다시 시도해주세요.';
 

--- a/src/shared/types/auth.ts
+++ b/src/shared/types/auth.ts
@@ -18,28 +18,8 @@ export type LoginResult = {
   birthday: string;
 };
 
-export type LoginResponse = {
-  isSuccess: boolean;
-  code: number;
-  message: string;
-  result: LoginResult;
-};
-
 export type ReissueTokenRequest = {
   refreshToken: string;
-};
-
-export type ReissueTokenResponse = {
-  isSuccess: boolean;
-  code: number;
-  message: string;
-  result: TokenResponse;
-};
-
-export type ApiErrorResponse = {
-  isSuccess: boolean;
-  code: number;
-  message: string;
 };
 
 export type User = {

--- a/src/shared/types/common.ts
+++ b/src/shared/types/common.ts
@@ -1,4 +1,4 @@
-export type ApiResponse<T> = {
+export type BaseResponse<T = void> = {
   isSuccess: boolean;
   code: number;
   message: string;

--- a/src/shared/types/inquiry.ts
+++ b/src/shared/types/inquiry.ts
@@ -1,5 +1,3 @@
-import type { ApiResponse } from './common';
-
 export type InquiryGroup = 'INQUIRY' | 'REPORT' | 'ETC';
 
 export type InquirySubGroup =
@@ -105,10 +103,10 @@ export type InquiryComment = {
   children: InquiryComment[];
 };
 
-export type AdminInquiryCommentListResponse = ApiResponse<{
+export type AdminInquiryCommentListResult = {
   hasNext: boolean;
   data: InquiryComment[];
-}>;
+};
 
 export type AdminInquiryCommentCreateRequest = {
   parentId: number | null;
@@ -120,30 +118,26 @@ export type AdminInquiryCommentMutationResult = InquiryComment & {
   pointDifference?: number;
 };
 
-export type AdminInquiryCommentCreateResponse =
-  ApiResponse<AdminInquiryCommentMutationResult>;
+export type AdminInquiryCommentCreateResult = AdminInquiryCommentMutationResult;
 
 export type AdminInquiryCommentUpdateRequest = {
   content: string;
 };
 
-export type AdminInquiryCommentUpdateResponse =
-  ApiResponse<AdminInquiryCommentMutationResult>;
+export type AdminInquiryCommentUpdateResult = AdminInquiryCommentMutationResult;
+export type AdminInquiryCommentDeleteResult = AdminInquiryCommentMutationResult;
 
-export type AdminInquiryCommentDeleteResponse =
-  ApiResponse<AdminInquiryCommentMutationResult>;
-
-export type AdminInquiryListResponse = ApiResponse<{
+export type AdminInquiryListResult = {
   hasNext: boolean;
   data: InquiryListItem[];
-}>;
+};
 
-export type AdminInquiryDetailResponse = ApiResponse<InquiryDetail>;
+export type AdminInquiryDetailResult = InquiryDetail;
 
 export type AdminInquiryStatusUpdateRequest = {
   status: InquiryStatus;
 };
 
-export type AdminInquiryStatusUpdateResponse = ApiResponse<{
+export type AdminInquiryStatusUpdateResult = {
   inquiryId: number;
-}>;
+};

--- a/src/shared/types/member.ts
+++ b/src/shared/types/member.ts
@@ -72,7 +72,7 @@ export type AdminUserListItem = {
   createdAt: string; // YYYY-MM-DD HH:MM:SS
 };
 
-export type AdminUserListResponse = {
+export type AdminUserListResult = {
   hasNext: boolean;
   data: AdminUserListItem[];
 };
@@ -100,12 +100,6 @@ export interface EditMemberInfo {
   userRoleId?: number;
 }
 
-export interface UpdateUserInfoResponse {
-  isSuccess: boolean;
-  code: number;
-  message: string;
-}
-
 export interface BlacklistHistoryItem {
   id?: number;
   encryptedUserId: string;
@@ -124,16 +118,11 @@ export interface BlacklistHistoryItem {
   deletedBy?: string | null;
 }
 
-export interface AdminBlacklistResponse {
-  isSuccess: boolean;
-  code: number;
-  message: string;
-  result: {
-    hasNext: boolean;
-    totalPage: number;
-    totalCount: number;
-    data: UserBlacklistHistory[];
-  };
+export interface AdminBlacklistResult {
+  hasNext: boolean;
+  totalPage: number;
+  totalCount: number;
+  data: UserBlacklistHistory[];
 }
 
 export interface AdminBlacklistReq {

--- a/src/shared/types/points.ts
+++ b/src/shared/types/points.ts
@@ -62,10 +62,3 @@ export interface ExcelPointBulkRewardResult {
   successRows: ExcelPointBulkSuccessRow[];
   notProcessedRows: ExcelPointBulkNotProcessedRow[];
 }
-
-export interface ExcelPointBulkRewardResponse {
-  isSuccess: boolean;
-  code: number;
-  message: string;
-  result: ExcelPointBulkRewardResult;
-}

--- a/src/shared/utils/error-handler.ts
+++ b/src/shared/utils/error-handler.ts
@@ -1,6 +1,6 @@
 import { isAxiosError } from 'axios';
 
-import type { ApiErrorResponse } from '@/shared/types';
+import type { BaseResponse } from '@/shared/types';
 
 /**
  * API 에러에서 메시지를 추출하는 유틸리티 함수
@@ -12,7 +12,7 @@ export function getErrorMessage(
   error: unknown,
   defaultMessage: string = '요청 처리 중 오류가 발생했습니다.'
 ): string {
-  if (isAxiosError<ApiErrorResponse>(error)) {
+  if (isAxiosError<BaseResponse<unknown>>(error)) {
     return error.response?.data?.message || defaultMessage;
   }
 


### PR DESCRIPTION
## 🔎 What is this PR?

Close #318

- [Figma]()
- [Notion]()

## 🎯 변경 사항

###### 주요 변경점을 설명해주세요.

- ApiResponse → BaseResponse<T> 제네릭으로 교체
- XxxResponse → XxxResult로 래퍼 제거 후 결과 타입만 정의
- API 레이어 내부에서 .result 언래핑, 호출자에게 실제 데이터만 노출
- void 반환 함수는 return 없이 await만 사용하도록 통일

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)
