### PR TITLE
feat: 게시글 댓글 삭제 사유 모달 적용

### DIFF
--- a/src/apis/comments.ts
+++ b/src/apis/comments.ts
@@ -75,22 +75,26 @@ export const searchComments = async (
 
 // 댓글 삭제 api
 export const deleteComment = async (
-  commentId: number
+  commentId: number,
+  memo: string
 ): Promise<AdminDeleteCommentResult> => {
   const response = await axiosInstance.delete<
     BaseResponse<AdminDeleteCommentResult>
-  >(`/v1/admin/comments/${commentId}`);
+  >(`/v1/admin/comments/${commentId}`, {
+    data: { memo },
+  });
   return response.data.result;
 };
 
 // 댓글 일괄 삭제 api
 export const bulkDeleteComments = async (
-  commentIds: number[]
+  commentIds: number[],
+  memo: string
 ): Promise<AdminCommentBulkDeleteResult> => {
   const response = await axiosInstance.delete<
     BaseResponse<AdminCommentBulkDeleteResult>
   >(`/v1/admin/comments`, {
-    data: { commentIds },
+    data: { commentIds, memo },
   });
   return response.data.result;
 };

--- a/src/apis/posts.ts
+++ b/src/apis/posts.ts
@@ -45,22 +45,26 @@ export const getDeletedPost = async (
 
 // 게시글 삭제 api
 export const deletePost = async (
-  postId: number
+  postId: number,
+  memo: string
 ): Promise<AdminGetPostResponse> => {
   const response = await axiosInstance.delete<
     BaseResponse<AdminGetPostResponse>
-  >(`/v1/admin/posts/${postId}`);
+  >(`/v1/admin/posts/${postId}`, {
+    data: { memo },
+  });
   return response.data.result;
 };
 
 // 여러 게시글 선택 삭제 api
 export const bulkDeletePosts = async (
-  postIds: number[]
+  postIds: number[],
+  memo: string
 ): Promise<AdminPostBulkDeleteResult> => {
   const response = await axiosInstance.delete<
     BaseResponse<AdminPostBulkDeleteResult>
   >('/v1/admin/posts', {
-    data: { postIds },
+    data: { postIds, memo },
   });
   return response.data.result;
 };

--- a/src/domains/Comments/components/CommentTable.tsx
+++ b/src/domains/Comments/components/CommentTable.tsx
@@ -1,6 +1,7 @@
 import { Loader2 } from 'lucide-react';
 
 import { PaginationBar } from '@/shared/components';
+import StatusChangeModal from '@/shared/components/StatusChangeModal';
 import { Table } from '@/shared/components/ui';
 
 import { useCommentTableState } from '../hooks/useCommentTableState';
@@ -33,6 +34,9 @@ export default function CommentTable({
     handleFilterByPostId,
     handleFilterByParentId,
     handleBulkDelete,
+    handleConfirmBulkDelete,
+    isDeleteModalOpen,
+    setIsDeleteModalOpen,
     handleBulkVisibility,
     handleBulkRestore,
     isDeletePending,
@@ -176,6 +180,15 @@ export default function CommentTable({
         onPageChange={onPageChange}
         hasNext={hasNext}
       />
+
+      {isDeleteModalOpen && (
+        <StatusChangeModal
+          target='COMMENT'
+          modalType='DELETE'
+          onClose={() => setIsDeleteModalOpen(false)}
+          onConfirmAction={handleConfirmBulkDelete}
+        />
+      )}
     </div>
   );
 }

--- a/src/domains/Comments/hooks/useBulkDeleteComment.ts
+++ b/src/domains/Comments/hooks/useBulkDeleteComment.ts
@@ -2,11 +2,17 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { bulkDeleteComments } from '@/apis';
 
+interface BulkDeleteCommentVariables {
+  commentIds: number[];
+  memo: string;
+}
+
 export const useBulkDeleteComment = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (commentIds: number[]) => bulkDeleteComments(commentIds),
+    mutationFn: ({ commentIds, memo }: BulkDeleteCommentVariables) =>
+      bulkDeleteComments(commentIds, memo),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['commentSearch'] });
     },

--- a/src/domains/Comments/hooks/useCommentTableState.ts
+++ b/src/domains/Comments/hooks/useCommentTableState.ts
@@ -25,6 +25,7 @@ export function useCommentTableState({
 }: UseCommentTableStateProps) {
   const navigate = useNavigate();
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const [urlSearchParams] = useSearchParams();
   const parentIdStr = urlSearchParams.get('parentId');
@@ -81,7 +82,11 @@ export function useCommentTableState({
 
   const handleBulkDelete = () => {
     if (selectedIds.length === 0) return;
+    setIsDeleteModalOpen(true);
+  };
 
+  const handleConfirmBulkDelete = (memo: string) => {
+    if (selectedIds.length === 0) return;
     const hasSelectedParentWithChildren = comments.some(
       (c) =>
         selectedIds.includes(c.commentId) &&
@@ -89,20 +94,22 @@ export function useCommentTableState({
         comments.some((child) => child.parentId === c.commentId)
     );
 
-    const message = hasSelectedParentWithChildren
-      ? '하위댓글도 모두 삭제하시겠습니까?'
-      : `선택한 ${selectedIds.length}개의 댓글을 삭제하시겠습니까?`;
+    if (hasSelectedParentWithChildren) {
+      toast.info('선택한 상위 댓글의 하위 댓글도 함께 삭제됩니다.');
+    }
 
-    if (!window.confirm(message)) return;
-
-    bulkDelete(selectedIds, {
-      onSuccess: (res) => {
-        toast.success(`${res.deletedCount}개의 댓글이 삭제되었습니다.`);
-        setSelectedIds([]);
-        void refetch();
-      },
-      onError: () => toast.error('댓글 일괄 삭제 중 오류가 발생했습니다.'),
-    });
+    bulkDelete(
+      { commentIds: selectedIds, memo },
+      {
+        onSuccess: (res) => {
+          toast.success(`${res.deletedCount}개의 댓글이 삭제되었습니다.`);
+          setSelectedIds([]);
+          setIsDeleteModalOpen(false);
+          void refetch();
+        },
+        onError: () => toast.error('댓글 일괄 삭제 중 오류가 발생했습니다.'),
+      }
+    );
   };
 
   const handleBulkVisibility = (isVisible: boolean) => {
@@ -224,6 +231,9 @@ export function useCommentTableState({
     handleFilterByPostId,
     handleFilterByParentId,
     handleBulkDelete,
+    handleConfirmBulkDelete,
+    isDeleteModalOpen,
+    setIsDeleteModalOpen,
     handleBulkVisibility,
     handleBulkRestore,
     isDeletePending,

--- a/src/domains/Comments/hooks/useDeleteComment.ts
+++ b/src/domains/Comments/hooks/useDeleteComment.ts
@@ -2,11 +2,17 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { deleteComment } from '@/apis';
 
+interface DeleteCommentVariables {
+  commentId: number;
+  memo: string;
+}
+
 export const useDeleteComment = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (commentId: number) => deleteComment(commentId),
+    mutationFn: ({ commentId, memo }: DeleteCommentVariables) =>
+      deleteComment(commentId, memo),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['commentSearch'] });
       queryClient.invalidateQueries({ queryKey: ['comments'] });

--- a/src/domains/Comments/types/comment.ts
+++ b/src/domains/Comments/types/comment.ts
@@ -55,6 +55,7 @@ export interface AdminDeleteCommentResult {
 
 export interface AdminCommentBulkDeleteRequest {
   commentIds: number[];
+  memo: string;
 }
 
 export interface AdminCommentBulkDeleteResult {
@@ -64,7 +65,7 @@ export interface AdminCommentBulkDeleteResult {
   deletedCommentIds: number[];
   notDeletedComments: {
     commentId: number;
-    reason: string;
+    memo: string;
   }[];
 }
 

--- a/src/domains/Posts/components/PostDetail/PostDetailCommentItem.tsx
+++ b/src/domains/Posts/components/PostDetail/PostDetailCommentItem.tsx
@@ -11,6 +11,7 @@ import {
 import { toast } from 'sonner';
 
 import { MemberInfoPopover } from '@/shared/components';
+import StatusChangeModal from '@/shared/components/StatusChangeModal';
 import { Badge, Button } from '@/shared/components/ui';
 import { formatDateTimeWithAmPm } from '@/shared/utils';
 
@@ -40,7 +41,6 @@ export default function PostDetailCommentItem({
   const [modalType, setModalType] = useState<'HIDE' | 'SHOW' | 'DELETE'>(
     'HIDE'
   );
-  const [reason, setReason] = useState('');
 
   // 댓글 노출/숨김 변경 Mutation
   const visibilityMutation = useMutation({
@@ -55,7 +55,6 @@ export default function PostDetailCommentItem({
       );
       queryClient.invalidateQueries({ queryKey: ['postComments'] });
       setIsModalOpen(false);
-      setReason('');
     },
     onError: () => {
       toast.error('댓글 상태 변경에 실패했습니다.');
@@ -64,23 +63,22 @@ export default function PostDetailCommentItem({
 
   // 댓글 삭제 Mutation
   const deleteMutation = useMutation({
-    mutationFn: () => deleteComment(comment.commentId),
+    mutationFn: (memo: string) => deleteComment(comment.commentId, memo),
     onSuccess: () => {
       toast.success('댓글이 삭제되었습니다.');
       queryClient.invalidateQueries({ queryKey: ['postComments'] });
       queryClient.invalidateQueries({ queryKey: ['post', comment.postId] });
       setIsModalOpen(false);
-      setReason('');
     },
     onError: () => {
       toast.error('댓글 삭제에 실패했습니다.');
     },
   });
-  const handleConfirmAction = () => {
-    if (!reason.trim()) return;
+  const handleConfirmAction = (memo: string) => {
+    if (!memo.trim()) return;
     if (modalType === 'HIDE') visibilityMutation.mutate(false);
     else if (modalType === 'SHOW') visibilityMutation.mutate(true);
-    else if (modalType === 'DELETE') deleteMutation.mutate();
+    else if (modalType === 'DELETE') deleteMutation.mutate(memo);
   };
 
   return (
@@ -224,57 +222,14 @@ export default function PostDetailCommentItem({
       </div>
       {/* 댓글 조치 사유 기입 모달 */}
       {isModalOpen && comment && (
-        <div
-          className='fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4'
-          onClick={(e) => e.stopPropagation()}
-        >
-          <div className='animate-in fade-in zoom-in-95 w-full max-w-md rounded-xl border border-gray-200 bg-white p-6 shadow-lg duration-150'>
-            <h3 className='mb-2 text-base font-bold text-gray-900'>
-              댓글{' '}
-              {modalType === 'HIDE'
-                ? '비공개'
-                : modalType === 'SHOW'
-                  ? '공개/복구'
-                  : '삭제'}{' '}
-              처리
-            </h3>
-            <p className='mb-4 text-xs text-gray-500'>
-              상태를 변경하는 사유를 작성해 주세요. (필수 입력)
-            </p>
-
-            <div className='flex flex-col gap-4'>
-              <textarea
-                className='min-h-[100px] w-full rounded-lg border border-gray-300 p-3 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none'
-                placeholder='사유를 입력하세요...'
-                value={reason}
-                onChange={(e) => setReason(e.target.value)}
-              />
-
-              <div className='mt-2 flex justify-end gap-2'>
-                <Button
-                  variant='outline'
-                  size='sm'
-                  onClick={() => {
-                    setIsModalOpen(false);
-                    setReason('');
-                  }}
-                  className='border-gray-300 bg-white text-xs text-gray-700 hover:bg-gray-50'
-                >
-                  취소
-                </Button>
-                <Button
-                  variant={modalType === 'DELETE' ? 'destructive' : 'default'}
-                  size='sm'
-                  onClick={handleConfirmAction}
-                  disabled={!reason.trim()}
-                  className={`text-xs ${modalType === 'DELETE' ? 'bg-red-600 hover:bg-red-700' : 'bg-blue-600 hover:bg-blue-700'}`}
-                >
-                  확인
-                </Button>
-              </div>
-            </div>
-          </div>
-        </div>
+        <StatusChangeModal
+          target='COMMENT'
+          modalType={modalType}
+          onClose={() => {
+            setIsModalOpen(false);
+          }}
+          onConfirmAction={handleConfirmAction}
+        />
       )}
     </div>
   );

--- a/src/domains/Posts/components/PostDetail/PostDetailManageCard.tsx
+++ b/src/domains/Posts/components/PostDetail/PostDetailManageCard.tsx
@@ -29,7 +29,7 @@ export default function PostDetailManageCard({
 
   // 게시물 삭제 Mutation
   const deleteMutation = useMutation({
-    mutationFn: () => deletePost(post.postId),
+    mutationFn: (memo: string) => deletePost(post.postId, memo),
     onSuccess: () => {
       toast.info(
         deleteCommentsAlso
@@ -56,7 +56,7 @@ export default function PostDetailManageCard({
   const handleConfirmAction = () => {
     if (!reason.trim()) return;
     if (modalType === 'DELETE') {
-      deleteMutation.mutate();
+      deleteMutation.mutate(reason);
     } else {
       // TODO: DELETE 외(RESTORE, HIDE) API 연동 시 아래 로직 구현
       toast.info('개발 중입니다');

--- a/src/domains/Posts/components/PostTable.tsx
+++ b/src/domains/Posts/components/PostTable.tsx
@@ -1,6 +1,7 @@
 import { Loader2 } from 'lucide-react';
 
 import { PaginationBar } from '@/shared/components';
+import StatusChangeModal from '@/shared/components/StatusChangeModal';
 import { Table } from '@/shared/components/ui';
 
 import { usePostTableState } from '../hooks/usePostTableState';
@@ -30,6 +31,9 @@ export default function PostTable({
     selectAllRef,
     handleSelectAll,
     handleBulkDelete,
+    handleConfirmBulkDelete,
+    isDeleteModalOpen,
+    setIsDeleteModalOpen,
     handleBulkVisibility,
     handleBulkRestore,
     isDeletePending,
@@ -163,6 +167,15 @@ export default function PostTable({
         onPageChange={onPageChange}
         hasNext={hasNext}
       />
+
+      {isDeleteModalOpen && (
+        <StatusChangeModal
+          target='POST'
+          modalType='DELETE'
+          onClose={() => setIsDeleteModalOpen(false)}
+          onConfirmAction={handleConfirmBulkDelete}
+        />
+      )}
     </div>
   );
 }

--- a/src/domains/Posts/hooks/useBulkDeletePost.ts
+++ b/src/domains/Posts/hooks/useBulkDeletePost.ts
@@ -2,11 +2,17 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { bulkDeletePosts } from '@/apis';
 
+interface BulkDeletePostVariables {
+  postIds: number[];
+  memo: string;
+}
+
 export const useBulkDeletePost = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (postIds: number[]) => bulkDeletePosts(postIds),
+    mutationFn: ({ postIds, memo }: BulkDeletePostVariables) =>
+      bulkDeletePosts(postIds, memo),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['posts'] });
     },

--- a/src/domains/Posts/hooks/useDeletePost.ts
+++ b/src/domains/Posts/hooks/useDeletePost.ts
@@ -2,11 +2,17 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { deletePost } from '@/apis';
 
+interface DeletePostVariables {
+  postId: number;
+  memo: string;
+}
+
 export const useDeletePost = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (postId: number) => deletePost(postId),
+    mutationFn: ({ postId, memo }: DeletePostVariables) =>
+      deletePost(postId, memo),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['posts'] });
     },

--- a/src/domains/Posts/hooks/usePostTableState.ts
+++ b/src/domains/Posts/hooks/usePostTableState.ts
@@ -20,6 +20,7 @@ export function usePostTableState({
   currentPage,
 }: UsePostTableStateProps) {
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   useEffect(() => {
     setSelectedIds([]);
@@ -79,26 +80,23 @@ export function usePostTableState({
 
   const handleBulkDelete = () => {
     if (selectedIds.length === 0) return;
+    setIsDeleteModalOpen(true);
+  };
 
-    const message = `선택한 ${selectedIds.length}개의 게시글을 삭제하시겠습니까?`;
-    if (!window.confirm(message)) return;
-
-    const deleteComments = window.confirm('댓글도 모두 삭제하시겠습니까?');
-
-    bulkDelete(selectedIds, {
-      onSuccess: (res) => {
-        const deletedCount = res?.deletedCount ?? selectedIds.length;
-        if (deleteComments) {
-          toast.success(
-            `${deletedCount}개의 게시글과 관련 댓글이 삭제되었습니다.`
-          );
-        } else {
+  const handleConfirmBulkDelete = (memo: string) => {
+    if (selectedIds.length === 0) return;
+    bulkDelete(
+      { postIds: selectedIds, memo },
+      {
+        onSuccess: (res) => {
+          const deletedCount = res?.deletedCount ?? selectedIds.length;
           toast.success(`${deletedCount}개의 게시글이 삭제되었습니다.`);
-        }
-        setSelectedIds([]);
-      },
-      onError: () => toast.error('게시글 일괄 삭제 중 오류가 발생했습니다.'),
-    });
+          setSelectedIds([]);
+          setIsDeleteModalOpen(false);
+        },
+        onError: () => toast.error('게시글 일괄 삭제 중 오류가 발생했습니다.'),
+      }
+    );
   };
 
   const handleBulkVisibility = (isVisible: boolean) => {
@@ -151,13 +149,16 @@ export function usePostTableState({
   const handleSingleDelete = (postId: number) => {
     if (!window.confirm('이 게시글을 삭제하시겠습니까?')) return;
 
-    singleDelete(postId, {
-      onSuccess: () => {
-        toast.success('게시글이 삭제되었습니다.');
-        setSelectedIds((prev) => prev.filter((id) => id !== postId));
-      },
-      onError: () => toast.error('게시글 삭제 중 오류가 발생했습니다.'),
-    });
+    singleDelete(
+      { postId, memo: '' },
+      {
+        onSuccess: () => {
+          toast.success('게시글이 삭제되었습니다.');
+          setSelectedIds((prev) => prev.filter((id) => id !== postId));
+        },
+        onError: () => toast.error('게시글 삭제 중 오류가 발생했습니다.'),
+      }
+    );
   };
 
   const allPostIds = posts.map((p) => p.postId);
@@ -191,6 +192,9 @@ export function usePostTableState({
     selectAllRef,
     handleSelectAll,
     handleBulkDelete,
+    handleConfirmBulkDelete,
+    isDeleteModalOpen,
+    setIsDeleteModalOpen,
     handleBulkVisibility,
     handleBulkRestore,
     handleSingleDelete,

--- a/src/domains/Posts/types/post.ts
+++ b/src/domains/Posts/types/post.ts
@@ -53,6 +53,7 @@ export interface AdminPostSearchRequest {
 
 export interface AdminPostBulkDeleteRequest {
   postIds: number[];
+  memo: string;
 }
 
 export interface AdminPostBulkDeleteResult {

--- a/src/shared/components/StatusChangeModal.tsx
+++ b/src/shared/components/StatusChangeModal.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+
+import { Button } from '@/shared/components/ui';
+
+interface StatusChangeModalProps {
+  target: 'POST' | 'COMMENT';
+  onClose: () => void;
+  modalType: 'HIDE' | 'SHOW' | 'DELETE' | 'RESTORE';
+  onConfirmAction: (reason: string) => void;
+}
+export default function StatusChangeModal({
+  target,
+  modalType,
+  onClose,
+  onConfirmAction,
+}: StatusChangeModalProps) {
+  const [reason, setReason] = useState('');
+  return (
+    <div
+      className='fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4'
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className='animate-in fade-in zoom-in-95 w-full max-w-md rounded-xl border border-gray-200 bg-white p-6 shadow-lg duration-150'>
+        <h3 className='mb-2 text-base font-bold text-gray-900'>
+          {target === 'POST' ? '게시글' : '댓글'}{' '}
+          {modalType === 'HIDE'
+            ? '비공개'
+            : modalType === 'SHOW'
+              ? '공개'
+              : modalType === 'RESTORE'
+                ? '복구'
+                : '삭제'}{' '}
+          처리
+        </h3>
+        <p className='mb-4 text-xs text-gray-500'>
+          상태를 변경하는 사유를 작성해 주세요.
+        </p>
+
+        <div className='flex flex-col gap-4'>
+          <textarea
+            className='min-h-[100px] w-full rounded-lg border border-gray-300 p-3 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none'
+            placeholder='사유를 입력하세요...'
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+          />
+
+          <div className='mt-2 flex justify-end gap-2'>
+            <Button
+              variant='outline'
+              size='sm'
+              onClick={onClose}
+              className='border-gray-300 bg-white text-xs text-gray-700 hover:bg-gray-50'
+            >
+              취소
+            </Button>
+            <Button
+              variant={modalType === 'DELETE' ? 'destructive' : 'default'}
+              size='sm'
+              onClick={() => onConfirmAction(reason)}
+              disabled={!reason.trim()}
+              className={`text-xs ${modalType === 'DELETE' ? 'bg-red-600 hover:bg-red-700' : 'bg-blue-600 hover:bg-blue-700'}`}
+            >
+              확인
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 🔎 What is this PR?

Close #336

- [Figma]()
- [Notion]()

## 🎯 변경 사항

###### 주요 변경점을 설명해주세요.

- 게시글/댓글 상태 변경 사유 입력에 사용할 공통 모달을 추가했습니다.
- 댓글 단건/일괄 삭제 요청에 memo 필드를 포함하도록 API와 mutation 타입을 정리했습니다.
- 게시글 단건/일괄 삭제 요청에 memo 필드를 포함하도록 API와 mutation 타입을 정리했습니다.
- 게시글/댓글 목록 및 상세 삭제 흐름에서 사유 모달을 거쳐 삭제 요청을 보내도록 연결했습니다.

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)

- 삭제 API의 DELETE body에 memo가 정상 전달되는지 확인 부탁드립니다.
- 게시글/댓글 목록과 상세 화면의 삭제 사유 입력 흐름이 기대 동작과 맞는지 확인 부탁드립니다.