### PR TITLE
feat: 시험후기 삭제 사유 저장 및 검색 필터 배치 개선

### DIFF
--- a/src/domains/Reviews/components/ExamDetailSection.test.tsx
+++ b/src/domains/Reviews/components/ExamDetailSection.test.tsx
@@ -167,4 +167,41 @@ describe('ExamDetailSection', () => {
     });
     expect(deleteExamReview).toHaveBeenCalledWith(101);
   });
+
+  test('기존 메모에 같은 삭제 사유가 있으면 중복으로 추가하지 않는다', async () => {
+    const user = userEvent.setup();
+    const memoWithDeleteReason =
+      '기존 운영자 메모\n\n[삭제 사유]\n부적절한 시험후기';
+    vi.mocked(updateExamReview).mockResolvedValue({
+      ...selectedExamReviewDetailWithMemo,
+      memo: memoWithDeleteReason,
+    });
+    vi.mocked(deleteExamReview).mockResolvedValue({ postId: 101 });
+
+    render(
+      <ExamDetailSection
+        selectedExamReview={selectedExamReview}
+        selectedExamReviewDetail={{
+          ...selectedExamReviewDetailWithMemo,
+          memo: memoWithDeleteReason,
+        }}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: '시험 후기 삭제' }));
+
+    const dialog = screen.getByRole('dialog', { name: '시험 후기 삭제' });
+    await user.type(
+      within(dialog).getByLabelText('삭제 사유'),
+      '부적절한 시험후기'
+    );
+    await user.click(within(dialog).getByRole('button', { name: '삭제' }));
+
+    await waitFor(() => {
+      expect(updateExamReview).toHaveBeenCalledWith(101, {
+        post: { memo: memoWithDeleteReason },
+      });
+    });
+    expect(deleteExamReview).toHaveBeenCalledWith(101);
+  });
 });

--- a/src/domains/Reviews/components/ExamDetailSection.test.tsx
+++ b/src/domains/Reviews/components/ExamDetailSection.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { toast } from 'sonner';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type {
+  ExamReview,
+  ExamReviewDetailResult,
+} from '@/domains/Reviews/types';
+
+import { deleteExamReview, updateExamReview } from '@/apis/reviews';
+
+import { ExamDetailSection } from './ExamDetailSection';
+
+vi.mock('@/apis/reviews', () => ({
+  confirmExamReview: vi.fn(),
+  deleteExamReview: vi.fn(),
+  downloadExamReviewFile: vi.fn(),
+  updateExamReview: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/domains/Reviews/components', () => ({
+  ExamReviewCommentSection: () => <div>댓글 목록</div>,
+  ExamReviewDetailInfoSection: () => <div>시험후기 상세정보 내용</div>,
+  ExamReviewLogSection: () => <div>관리 이력 내용</div>,
+  ExamReviewPostInfoSection: () => <div>게시글 및 작성자 정보 내용</div>,
+  ExamReviewUpdateConfirmModal: () => null,
+}));
+
+const selectedExamReview: ExamReview = {
+  id: 101,
+  status: 'UNCONFIRMED',
+  reviewTitle: '운영체제 중간고사',
+  courseName: '운영체제',
+  professor: '김교수',
+  semester: '2026-1',
+  examType: '중간고사',
+  classNumber: '1',
+  questionDetail: '서술형 3문항',
+  uploadTime: '2026-04-20 10:00',
+  userDisplay: '익명',
+  isDiscussed: false,
+  isReported: false,
+  reportCount: 0,
+  processStatuses: [],
+};
+
+const selectedExamReviewDetail: ExamReviewDetailResult = {
+  encryptedUserId: 'encrypted-user-id',
+  userDisplay: '익명',
+  postId: 101,
+  title: '운영체제 중간고사',
+  commentCount: 0,
+  status: 'UNCONFIRMED',
+  createdAt: '2026-04-20T10:00:00',
+  lectureName: '운영체제',
+  professor: '김교수',
+  classNumber: 1,
+  lectureYear: 2026,
+  semester: 'FIRST',
+  lectureType: 'MAJOR_REQUIRED',
+  isPF: false,
+  isOnline: false,
+  examType: 'MIDTERM',
+  isConfirmed: false,
+  isDiscussed: false,
+  deletionStatus: null,
+  isSanctioned: false,
+  visibilityStatus: null,
+  memo: null,
+  fileName: 'exam.pdf',
+  questionDetail: '서술형 3문항',
+  logs: [],
+};
+
+const selectedExamReviewDetailWithMemo: ExamReviewDetailResult = {
+  ...selectedExamReviewDetail,
+  memo: '기존 운영자 메모',
+};
+
+describe('ExamDetailSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('삭제 사유를 메모로 저장한 뒤 시험 후기를 삭제한다', async () => {
+    const user = userEvent.setup();
+    const onDeleteSuccess = vi.fn();
+    vi.mocked(updateExamReview).mockResolvedValue({
+      ...selectedExamReviewDetail,
+      memo: '부적절한 시험후기',
+    });
+    vi.mocked(deleteExamReview).mockResolvedValue({ postId: 101 });
+
+    render(
+      <ExamDetailSection
+        selectedExamReview={selectedExamReview}
+        selectedExamReviewDetail={selectedExamReviewDetail}
+        onDeleteSuccess={onDeleteSuccess}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: '시험 후기 삭제' }));
+
+    const dialog = screen.getByRole('dialog', { name: '시험 후기 삭제' });
+    const reasonInput = within(dialog).getByLabelText('삭제 사유');
+    const confirmButton = within(dialog).getByRole('button', { name: '삭제' });
+
+    expect(confirmButton).toBeDisabled();
+
+    await user.type(reasonInput, '  부적절한 시험후기  ');
+    expect(confirmButton).toBeEnabled();
+
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(updateExamReview).toHaveBeenCalledWith(101, {
+        post: { memo: '[삭제 사유]\n부적절한 시험후기' },
+      });
+    });
+    expect(deleteExamReview).toHaveBeenCalledWith(101);
+    expect(toast.success).toHaveBeenCalledWith(
+      '시험 후기가 성공적으로 삭제되었습니다.'
+    );
+    expect(onDeleteSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  test('삭제 모달에서 기존 메모를 보여주고 삭제 사유를 기존 메모 아래에 저장한다', async () => {
+    const user = userEvent.setup();
+    vi.mocked(updateExamReview).mockResolvedValue({
+      ...selectedExamReviewDetailWithMemo,
+      memo: '기존 운영자 메모\n\n[삭제 사유]\n부적절한 시험후기',
+    });
+    vi.mocked(deleteExamReview).mockResolvedValue({ postId: 101 });
+
+    render(
+      <ExamDetailSection
+        selectedExamReview={selectedExamReview}
+        selectedExamReviewDetail={selectedExamReviewDetailWithMemo}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: '시험 후기 삭제' }));
+
+    const dialog = screen.getByRole('dialog', { name: '시험 후기 삭제' });
+    expect(within(dialog).getByLabelText('기존 메모')).toHaveValue(
+      '기존 운영자 메모'
+    );
+
+    await user.type(
+      within(dialog).getByLabelText('삭제 사유'),
+      '부적절한 시험후기'
+    );
+    await user.click(within(dialog).getByRole('button', { name: '삭제' }));
+
+    await waitFor(() => {
+      expect(updateExamReview).toHaveBeenCalledWith(101, {
+        post: { memo: '기존 운영자 메모\n\n[삭제 사유]\n부적절한 시험후기' },
+      });
+    });
+    expect(deleteExamReview).toHaveBeenCalledWith(101);
+  });
+});

--- a/src/domains/Reviews/components/ExamDetailSection.tsx
+++ b/src/domains/Reviews/components/ExamDetailSection.tsx
@@ -10,6 +10,7 @@ import {
   ConfirmModal,
   Skeleton,
   Tabs,
+  Textarea,
 } from '@/shared/components/ui';
 
 import {
@@ -128,6 +129,8 @@ export function ExamDetailSection({
   >('review');
   const [formData, setFormData] = useState<FormData>(DEFAULT_FORM_DATA);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [deleteReason, setDeleteReason] = useState('');
+  const [isDeleting, setIsDeleting] = useState(false);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
@@ -341,6 +344,16 @@ export function ExamDetailSection({
     setIsSaveModalOpen(true);
   };
 
+  const openDeleteModal = () => {
+    setDeleteReason('');
+    setIsDeleteModalOpen(true);
+  };
+
+  const closeDeleteModal = () => {
+    setIsDeleteModalOpen(false);
+    setDeleteReason('');
+  };
+
   const handleFileDownload = async () => {
     if (!selectedExamReview || !formData.fileName) {
       toast.error('다운로드할 파일이 없습니다.');
@@ -490,14 +503,29 @@ export function ExamDetailSection({
   };
 
   const handleDeleteClick = async () => {
+    const trimmedDeleteReason = deleteReason.trim();
+    const existingMemo = selectedExamReviewDetail?.memo?.trim();
+    const deleteMemo = existingMemo
+      ? `${existingMemo}\n\n[삭제 사유]\n${trimmedDeleteReason}`
+      : `[삭제 사유]\n${trimmedDeleteReason}`;
+
+    if (!trimmedDeleteReason) {
+      toast.error('삭제 사유를 입력해주세요.');
+      return;
+    }
+
     try {
       if (!selectedExamReview?.id) {
         toast.error('선택된 시험 후기가 없습니다.');
         return;
       }
+      setIsDeleting(true);
+      await updateExamReview(selectedExamReview.id, {
+        post: { memo: deleteMemo },
+      });
       await deleteExamReview(selectedExamReview.id);
       toast.success('시험 후기가 성공적으로 삭제되었습니다.');
-      setIsDeleteModalOpen(false);
+      closeDeleteModal();
       resetForm();
       onDeleteSuccess?.();
     } catch (error: unknown) {
@@ -505,6 +533,8 @@ export function ExamDetailSection({
         (isAxiosError(error) && error.response?.data?.message) ||
         '시험 후기 삭제에 실패했습니다.';
       toast.error(errorMessage);
+    } finally {
+      setIsDeleting(false);
     }
   };
 
@@ -523,8 +553,9 @@ export function ExamDetailSection({
           {selectedExamReview && (
             <button
               type='button'
+              aria-label='시험 후기 삭제'
               className='rounded-sm bg-red-100 p-2 hover:bg-red-200 disabled:cursor-not-allowed disabled:opacity-60'
-              onClick={() => setIsDeleteModalOpen(true)}
+              onClick={openDeleteModal}
               disabled={isDisabled}
             >
               <Trash2 className='h-4 w-4 text-red-500' />
@@ -682,13 +713,49 @@ export function ExamDetailSection({
 
       <ConfirmModal
         isOpen={isDeleteModalOpen}
-        confirmText='삭제'
+        confirmText={isDeleting ? '삭제 중' : '삭제'}
+        confirmButtonClassName='bg-red-600 text-white hover:bg-red-700'
+        confirmDisabled={!deleteReason.trim() || isDeleting}
         closeText='취소'
-        onClose={() => setIsDeleteModalOpen(false)}
+        onClose={closeDeleteModal}
         onConfirm={handleDeleteClick}
         title='시험 후기 삭제'
-        description='시험 후기를 삭제하시겠습니까?'
-      />
+        description='기존 메모 아래에 삭제 사유를 추가해 저장합니다.'
+      >
+        <div className='flex flex-col gap-4'>
+          <div className='flex flex-col gap-2'>
+            <label
+              htmlFor='exam-review-existing-memo'
+              className='text-sm font-medium text-gray-700'
+            >
+              기존 메모
+            </label>
+            <Textarea
+              id='exam-review-existing-memo'
+              value={selectedExamReviewDetail?.memo ?? ''}
+              placeholder='기존 메모가 없습니다.'
+              className='min-h-[96px] resize-none bg-gray-50'
+              readOnly
+            />
+          </div>
+          <div className='flex flex-col gap-2'>
+            <label
+              htmlFor='exam-review-delete-reason'
+              className='text-sm font-medium text-gray-700'
+            >
+              삭제 사유
+            </label>
+            <Textarea
+              id='exam-review-delete-reason'
+              value={deleteReason}
+              onChange={(event) => setDeleteReason(event.target.value)}
+              placeholder='삭제 사유를 입력해주세요.'
+              className='min-h-[120px] resize-none'
+              disabled={isDeleting}
+            />
+          </div>
+        </div>
+      </ConfirmModal>
     </article>
   );
 }

--- a/src/domains/Reviews/components/ExamDetailSection.tsx
+++ b/src/domains/Reviews/components/ExamDetailSection.tsx
@@ -504,21 +504,23 @@ export function ExamDetailSection({
 
   const handleDeleteClick = async () => {
     const trimmedDeleteReason = deleteReason.trim();
-    const existingMemo = selectedExamReviewDetail?.memo?.trim();
-    const deleteMemo = existingMemo
-      ? `${existingMemo}\n\n[삭제 사유]\n${trimmedDeleteReason}`
-      : `[삭제 사유]\n${trimmedDeleteReason}`;
-
     if (!trimmedDeleteReason) {
       toast.error('삭제 사유를 입력해주세요.');
       return;
     }
 
+    if (!selectedExamReview?.id) {
+      toast.error('선택된 시험 후기가 없습니다.');
+      return;
+    }
+
+    const existingMemo = selectedExamReviewDetail?.memo?.trim();
+    const deleteReasonMarker = `[삭제 사유]\n${trimmedDeleteReason}`;
+    const deleteMemo = existingMemo?.includes(deleteReasonMarker)
+      ? existingMemo
+      : [existingMemo, deleteReasonMarker].filter(Boolean).join('\n\n');
+
     try {
-      if (!selectedExamReview?.id) {
-        toast.error('선택된 시험 후기가 없습니다.');
-        return;
-      }
       setIsDeleting(true);
       await updateExamReview(selectedExamReview.id, {
         post: { memo: deleteMemo },

--- a/src/domains/Reviews/components/ExamReviewDetailInfoSection.test.tsx
+++ b/src/domains/Reviews/components/ExamReviewDetailInfoSection.test.tsx
@@ -63,4 +63,19 @@ describe('ExamReviewDetailInfoSection', () => {
     expect(examTypeAndQuestionsField.nextElementSibling).toBe(memoField);
     expect(memoField).not.toHaveClass('md:col-span-2');
   });
+
+  test('메모 입력란은 시험 유형 및 문항수 입력란과 같은 높이를 사용한다', () => {
+    renderExamReviewDetailInfoSection();
+
+    const examTypeAndQuestionsField = getFieldByLabel('시험 유형 및 문항수');
+    const memoField = getFieldByLabel('메모');
+    const examTypeAndQuestionsTextarea =
+      examTypeAndQuestionsField.querySelector('textarea');
+    const memoTextarea = memoField.querySelector('textarea');
+
+    expect(examTypeAndQuestionsTextarea).not.toBeNull();
+    expect(memoTextarea).not.toBeNull();
+    expect(examTypeAndQuestionsTextarea).toHaveClass('min-h-[110px]');
+    expect(memoTextarea).toHaveClass('min-h-[110px]');
+  });
 });

--- a/src/domains/Reviews/components/ExamReviewDetailInfoSection.test.tsx
+++ b/src/domains/Reviews/components/ExamReviewDetailInfoSection.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+  ExamReviewDetailInfoSection,
+  type ExamReviewDetailInfoSectionFormData,
+} from './ExamReviewDetailInfoSection';
+
+const formData: ExamReviewDetailInfoSectionFormData = {
+  isConfirmed: false,
+  isDiscussed: false,
+  lectureName: '운영체제',
+  professorName: '김교수',
+  lectureType: 'MAJOR_REQUIRED',
+  semester: '2026-1',
+  classNumber: 1,
+  examType: '중간고사',
+  isPF: 'X',
+  isOnline: 'X',
+  deletionStatus: null,
+  isSanctioned: false,
+  visibilityStatus: null,
+  memo: '운영자 메모',
+  fileName: 'exam.pdf',
+  examTypeAndQuestions: '서술형 3문항',
+};
+
+function renderExamReviewDetailInfoSection() {
+  return render(
+    <ExamReviewDetailInfoSection
+      formData={formData}
+      setFormData={vi.fn()}
+      isFormDisabled={false}
+      onFileDownload={vi.fn()}
+      fileInputRef={{ current: null }}
+      selectedFile={null}
+      setSelectedFile={vi.fn()}
+    />
+  );
+}
+
+function getFieldByLabel(label: string) {
+  const field = screen.getByText(label).closest('[data-slot="field"]');
+
+  expect(field).not.toBeNull();
+
+  return field as HTMLElement;
+}
+
+describe('ExamReviewDetailInfoSection', () => {
+  test('메모 입력란은 시험 유형 및 문항수 오른쪽 칸에 배치된다', () => {
+    renderExamReviewDetailInfoSection();
+
+    const examTypeAndQuestionsField = getFieldByLabel('시험 유형 및 문항수');
+    const memoField = getFieldByLabel('메모');
+
+    expect(examTypeAndQuestionsField.parentElement).toBe(
+      memoField.parentElement
+    );
+    expect(examTypeAndQuestionsField.parentElement).toHaveClass(
+      'md:grid-cols-2'
+    );
+    expect(examTypeAndQuestionsField.nextElementSibling).toBe(memoField);
+    expect(memoField).not.toHaveClass('md:col-span-2');
+  });
+});

--- a/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
+++ b/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
@@ -393,7 +393,7 @@ export function ExamReviewDetailInfoSection({
             />
           </Field.Content>
         </Field>
-        <Field className='gap-0 md:col-span-2'>
+        <Field className='gap-0'>
           <Field.Label>메모</Field.Label>
           <Field.Content>
             <Textarea

--- a/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
+++ b/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
@@ -401,7 +401,7 @@ export function ExamReviewDetailInfoSection({
               onChange={(e) => setFormData({ memo: e.target.value })}
               disabled={isFormDisabled}
               rows={3}
-              className='min-h-[96px] resize-none'
+              className='min-h-[110px] resize-none'
             />
           </Field.Content>
         </Field>

--- a/src/domains/Reviews/components/ExamSearch.tsx
+++ b/src/domains/Reviews/components/ExamSearch.tsx
@@ -320,7 +320,7 @@ export default function ExamSearch({
         <div className='relative w-[220px]'>
           <input
             type='text'
-            placeholder='시험후기명 검색'
+            placeholder='시험후기명 또는 postId 검색'
             value={keywordPost}
             onChange={(e) => setKeywordPost(e.target.value)}
             onKeyDown={handleKeyDown}

--- a/src/domains/Reviews/components/ExamSearch.tsx
+++ b/src/domains/Reviews/components/ExamSearch.tsx
@@ -372,12 +372,6 @@ export default function ExamSearch({
           className='h-9 w-[150px] text-[13px]'
           aria-label='검색 종료일'
         />
-        <div className='flex items-center gap-2'>
-          <Button onClick={handleSearch}>조회</Button>
-          <Button variant='outline' onClick={handleSearchOptionReset}>
-            검색 옵션 초기화
-          </Button>
-        </div>
       </div>
 
       {/* 필터 Select들 */}
@@ -550,6 +544,19 @@ export default function ExamSearch({
           />
           <span>신고 있음</span>
         </label>
+      </div>
+
+      <div className='flex w-fit items-center gap-2'>
+        <Button className='min-w-[72px]' onClick={handleSearch}>
+          조회
+        </Button>
+        <Button
+          className='min-w-[136px]'
+          variant='outline'
+          onClick={handleSearchOptionReset}
+        >
+          검색 옵션 초기화
+        </Button>
       </div>
     </div>
   );

--- a/src/shared/components/ui/confirm-modal.tsx
+++ b/src/shared/components/ui/confirm-modal.tsx
@@ -8,6 +8,7 @@ interface ConfirmModalProps {
   onClose: () => void;
   confirmText?: string;
   confirmButtonClassName?: string;
+  confirmDisabled?: boolean;
   closeText?: string;
   children?: React.ReactNode;
 }
@@ -20,6 +21,7 @@ export function ConfirmModal({
   onClose,
   confirmText = '확인',
   confirmButtonClassName,
+  confirmDisabled = false,
   closeText = '취소',
   children,
 }: ConfirmModalProps) {
@@ -43,6 +45,7 @@ export function ConfirmModal({
             type='button'
             onClick={onConfirm}
             className={confirmButtonClassName}
+            disabled={confirmDisabled}
           >
             {confirmText}
           </Button>


### PR DESCRIPTION
## 🔎 What is this PR?

Close #340


## 🎯 변경 사항

###### 주요 변경점을 설명해주세요.

- 시험후기 삭제 시 삭제 사유를 입력받고 기존 메모 아래에 저장
- 시험후기 상세 메모 입력란을 시험 유형 및 문항수 오른쪽 칸에 배치하고 높이 정렬
- 시험후기 검색 placeholder를 postId 검색 가능 문구로 변경하고 조회/초기화 버튼을 필터 아래 좌측에 배치

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)

- 삭제 사유 저장 시 기존 메모 보존과 `[삭제 사유]` 구분 형식 확인
- 삭제 사유 미입력 시 삭제 버튼 비활성화와 삭제 중 상태 처리 확인
- 시험후기 검색 필터 영역에서 버튼 위치와 placeholder 문구 확인