### PR TITLE
style: 게시글 삭제 토스트 메시지 종류 수정

### DIFF
--- a/src/domains/Posts/components/PostDetail/PostDetailManageCard.tsx
+++ b/src/domains/Posts/components/PostDetail/PostDetailManageCard.tsx
@@ -31,11 +31,12 @@ export default function PostDetailManageCard({
   const deleteMutation = useMutation({
     mutationFn: (memo: string) => deletePost(post.postId, memo),
     onSuccess: () => {
-      toast.info(
-        deleteCommentsAlso
-          ? '게시글은 삭제되었지만 댓글 삭제 기능은 개발 중입니다.'
-          : '게시글이 삭제되었습니다.'
-      );
+      if (deleteCommentsAlso) {
+        toast.info('게시글은 삭제되었지만 댓글 삭제 기능은 개발 중입니다.');
+      } else {
+        toast.success('게시글이 삭제되었습니다.');
+      }
+
       setIsModalOpen(false);
       setReason('');
       setDeleteCommentsAlso(false);

--- a/src/domains/Posts/components/PostDetail/PostDetailManageCard.tsx
+++ b/src/domains/Posts/components/PostDetail/PostDetailManageCard.tsx
@@ -30,8 +30,11 @@ export default function PostDetailManageCard({
   // 게시물 삭제 Mutation
   const deleteMutation = useMutation({
     mutationFn: (memo: string) => deletePost(post.postId, memo),
-    onSuccess: () => {
-      if (deleteCommentsAlso) {
+    onMutate: () => {
+      return { deleteCommentsAlsoAtMutation: deleteCommentsAlso };
+    },
+    onSuccess: (_data, _variables, context) => {
+      if (context?.deleteCommentsAlsoAtMutation) {
         toast.info('게시글은 삭제되었지만 댓글 삭제 기능은 개발 중입니다.');
       } else {
         toast.success('게시글이 삭제되었습니다.');


### PR DESCRIPTION
## 🔎 What is this PR?

Close #344

- [Figma]()
- [Notion]()

## 🎯 변경 사항

###### 주요 변경점을 설명해주세요.

- 게시글 삭제 완료 시 성공 토스트가 표시되도록 변경했습니다.
- 댓글 동시 삭제 옵션이 선택된 경우 기존 안내 토스트를 유지했습니다.

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)

- 게시글 삭제 성공/댓글 동시 삭제 옵션별 토스트 타입이 의도대로 분기되는지 확인해주세요.