### PR TITLE
fix: 게시글 상세 댓글 페이지네이션 총 페이지 전달

### DIFF
--- a/src/domains/Posts/components/PostDetail/PostDetailCommentList.tsx
+++ b/src/domains/Posts/components/PostDetail/PostDetailCommentList.tsx
@@ -35,7 +35,6 @@ export default function PostDetailCommentList({
   });
 
   const comments = useMemo(() => data?.data ?? [], [data]);
-  const hasNext = data?.hasNext ?? false;
   const totalPage = data?.totalPage ?? 1;
 
   return (
@@ -67,7 +66,7 @@ export default function PostDetailCommentList({
         </div>
       )}
 
-      {!isLoading && (currentPage > 1 || hasNext) && (
+      {!isLoading && totalPage > 1 && (
         <PaginationBar
           currentPage={currentPage}
           onPageChange={setCurrentPage}

--- a/src/domains/Posts/components/PostDetail/PostDetailCommentList.tsx
+++ b/src/domains/Posts/components/PostDetail/PostDetailCommentList.tsx
@@ -36,6 +36,7 @@ export default function PostDetailCommentList({
 
   const comments = useMemo(() => data?.data ?? [], [data]);
   const hasNext = data?.hasNext ?? false;
+  const totalPage = data?.totalPage ?? 1;
 
   return (
     <div className='mt-6 flex flex-col gap-4 rounded-xl border border-gray-200 bg-white p-6 shadow-sm'>
@@ -70,6 +71,7 @@ export default function PostDetailCommentList({
         <PaginationBar
           currentPage={currentPage}
           onPageChange={setCurrentPage}
+          totalPage={totalPage}
         />
       )}
     </div>

--- a/src/domains/Posts/components/PostDetail/PostDetailCommentList.tsx
+++ b/src/domains/Posts/components/PostDetail/PostDetailCommentList.tsx
@@ -1,9 +1,9 @@
 import { useMemo, useState } from 'react';
 
 import { useQuery } from '@tanstack/react-query';
-import { ChevronLeft, ChevronRight, Loader2 } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 
-import { Button } from '@/shared/components/ui';
+import { PaginationBar } from '@/shared/components';
 
 import { searchComments } from '@/apis/comments';
 
@@ -67,27 +67,10 @@ export default function PostDetailCommentList({
       )}
 
       {!isLoading && (currentPage > 1 || hasNext) && (
-        <div className='flex items-center justify-center gap-2 border-t border-gray-100 pt-4'>
-          <Button
-            variant='outline'
-            size='sm'
-            className='h-7 w-7 p-0'
-            disabled={currentPage === 1}
-            onClick={() => setCurrentPage((p) => p - 1)}
-          >
-            <ChevronLeft className='h-4 w-4' />
-          </Button>
-          <span className='text-xs text-gray-500'>{currentPage}페이지</span>
-          <Button
-            variant='outline'
-            size='sm'
-            className='h-7 w-7 p-0'
-            disabled={!hasNext}
-            onClick={() => setCurrentPage((p) => p + 1)}
-          >
-            <ChevronRight className='h-4 w-4' />
-          </Button>
-        </div>
+        <PaginationBar
+          currentPage={currentPage}
+          onPageChange={setCurrentPage}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## 🔎 What is this PR?

Close #346

- [Figma]()
- [Notion]()

## 🎯 변경 사항

###### 주요 변경점을 설명해주세요.

- 게시글 상세 댓글 목록의 `PaginationBar`에 API 응답의 `totalPage` 값을 전달하도록 수정했습니다.
- `totalPage`가 없을 때는 기본값 1을 사용하도록 처리했습니다.

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)

- 댓글 페이지네이션이 전체 페이지 수 기준으로 정상 표시되는지 확인 부탁드립니다.