### PR TITLE
style: 게시글 필터 버튼 배치 조정

### DIFF
--- a/src/domains/Comments/components/CommentFilterPanel.tsx
+++ b/src/domains/Comments/components/CommentFilterPanel.tsx
@@ -212,14 +212,6 @@ export const CommentFilterPanel = ({
         </div>
       </div>
 
-      {/* 초기화 */}
-      <button
-        onClick={handleReset}
-        className='w-full rounded border border-gray-200 py-2 text-sm text-gray-600 hover:bg-gray-50'
-      >
-        초기화
-      </button>
-
       {/* 게시판 필터 */}
       <div className='flex flex-col gap-2'>
         <label className='text-sm text-gray-600'>게시판 필터</label>
@@ -290,21 +282,26 @@ export const CommentFilterPanel = ({
         </div>
       </div>
 
-      {/* 검색 버튼 + 총 개수 */}
-      <div className='flex items-center justify-between'>
-        {totalCount !== undefined && (
-          <span className='text-sm text-gray-500'>
-            총 <span className='font-semibold text-blue-600'>{totalCount}</span>
-            개의 댓글
-          </span>
-        )}
+      <div className='flex w-full gap-4'>
+        <button
+          onClick={handleReset}
+          className='w-full rounded border border-gray-200 py-2 text-sm text-gray-600 hover:bg-gray-50'
+        >
+          초기화
+        </button>
         <button
           onClick={() => onFilterChange(filters)}
-          className='rounded bg-gray-900 px-6 py-2 text-sm font-semibold text-white hover:bg-gray-700'
+          className='w-full rounded bg-gray-900 py-2 text-sm font-semibold text-white hover:bg-gray-700'
         >
           검색
         </button>
       </div>
+      {totalCount !== undefined && (
+        <span className='text-sm text-gray-500'>
+          총 <span className='font-semibold text-blue-600'>{totalCount}</span>
+          개의 댓글
+        </span>
+      )}
     </div>
   );
 };

--- a/src/domains/Posts/components/PostFilterPanel.tsx
+++ b/src/domains/Posts/components/PostFilterPanel.tsx
@@ -190,14 +190,6 @@ export const PostFilterPanel = ({
         </div>
       </div>
 
-      {/* 초기화 */}
-      <button
-        onClick={handleReset}
-        className='w-full rounded border border-gray-200 py-2 text-sm text-gray-600 hover:bg-gray-50'
-      >
-        초기화
-      </button>
-
       {/* 공지만 보기 */}
       <label className='flex items-center gap-2 text-sm text-gray-700'>
         <input
@@ -291,12 +283,20 @@ export const PostFilterPanel = ({
             개의 게시글
           </span>
         )}
-        <button
-          onClick={() => onFilterChange(filters)}
-          className='rounded bg-gray-900 px-6 py-2 text-sm font-semibold text-white hover:bg-gray-700'
-        >
-          검색
-        </button>
+        <div className='flex w-full gap-4'>
+          <button
+            onClick={handleReset}
+            className='w-full rounded border border-gray-200 py-2 text-sm text-gray-600 hover:bg-gray-50'
+          >
+            초기화
+          </button>
+          <button
+            onClick={() => onFilterChange(filters)}
+            className='w-full rounded bg-gray-900 py-2 text-sm font-semibold text-white hover:bg-gray-700'
+          >
+            검색
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/domains/Posts/components/PostFilterPanel.tsx
+++ b/src/domains/Posts/components/PostFilterPanel.tsx
@@ -274,30 +274,26 @@ export const PostFilterPanel = ({
           ))}
         </div>
       </div>
-
-      {/* 검색 버튼 + 총 개수 */}
-      <div className='flex items-center justify-between'>
-        {totalCount !== undefined && (
-          <span className='text-sm text-gray-500'>
-            총 <span className='font-semibold text-blue-600'>{totalCount}</span>
-            개의 게시글
-          </span>
-        )}
-        <div className='flex w-full gap-4'>
-          <button
-            onClick={handleReset}
-            className='w-full rounded border border-gray-200 py-2 text-sm text-gray-600 hover:bg-gray-50'
-          >
-            초기화
-          </button>
-          <button
-            onClick={() => onFilterChange(filters)}
-            className='w-full rounded bg-gray-900 py-2 text-sm font-semibold text-white hover:bg-gray-700'
-          >
-            검색
-          </button>
-        </div>
+      <div className='flex w-full gap-4'>
+        <button
+          onClick={handleReset}
+          className='w-full rounded border border-gray-200 py-2 text-sm text-gray-600 hover:bg-gray-50'
+        >
+          초기화
+        </button>
+        <button
+          onClick={() => onFilterChange(filters)}
+          className='w-full rounded bg-gray-900 py-2 text-sm font-semibold text-white hover:bg-gray-700'
+        >
+          검색
+        </button>
       </div>
+      {totalCount !== undefined && (
+        <span className='text-sm text-gray-500'>
+          총 <span className='font-semibold text-blue-600'>{totalCount}</span>
+          개의 게시글
+        </span>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## 🔎 What is this PR?

Close #347

- [Figma]()
- [Notion]()

## 🎯 변경 사항

###### 주요 변경점을 설명해주세요.

- 게시글 필터 패널의 초기화 버튼 위치를 하단 액션 영역으로 이동했습니다.
- 초기화 버튼과 검색 버튼이 같은 행에서 동일한 너비로 보이도록 배치를 조정했습니다.

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)

- 필터 패널 하단의 초기화/검색 버튼 배치가 의도한 UI와 맞는지 확인 부탁드립니다.