### PR TITLE
fix: 시험후기 필터 조회 시점 조정

### DIFF
--- a/src/domains/Reviews/components/ExamMultiSelect.tsx
+++ b/src/domains/Reviews/components/ExamMultiSelect.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 
 import * as Popover from '@radix-ui/react-popover';
 
@@ -12,7 +12,8 @@ export interface ExamMultiSelectProps {
   side?: 'top' | 'bottom' | 'left' | 'right';
   align?: 'start' | 'center' | 'end';
   showStatusDot?: boolean;
-  children: React.ReactNode;
+  renderOption?: (option: string) => ReactNode;
+  children: ReactNode;
 }
 
 export const ExamMultiSelect = ({
@@ -23,6 +24,7 @@ export const ExamMultiSelect = ({
   side = 'bottom',
   align = 'start',
   showStatusDot = false,
+  renderOption,
   children,
 }: ExamMultiSelectProps) => {
   const [open, setOpen] = useState(false);
@@ -126,7 +128,9 @@ export const ExamMultiSelect = ({
                     }`}
                     tabIndex={-1}
                   />
-                  <span className='flex-1 text-left'>{option}</span>
+                  <span className='flex-1 text-left'>
+                    {renderOption ? renderOption(option) : option}
+                  </span>
                   {showStatusDot && statusOption && (
                     <div className='ml-2 h-2 w-2 shrink-0 rounded-full bg-blue-500' />
                   )}

--- a/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
+++ b/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
@@ -135,7 +135,8 @@ export function ExamReviewDetailInfoSection({
                 {renderStatusBadge(
                   formData.isDiscussed ? '논의 있음' : '논의 없음',
                   formData.isDiscussed,
-                  'bg-blue-50 text-blue-700'
+                  'bg-blue-50 text-blue-700',
+                  'bg-gray-100 text-gray-700'
                 )}
               </Select.Trigger>
               <Select.Content>
@@ -143,14 +144,16 @@ export function ExamReviewDetailInfoSection({
                   {renderStatusBadge(
                     '논의 있음',
                     true,
-                    'bg-blue-50 text-blue-700'
+                    'bg-blue-50 text-blue-700',
+                    'bg-gray-100 text-gray-700'
                   )}
                 </Select.Item>
                 <Select.Item value='false'>
                   {renderStatusBadge(
                     '논의 없음',
                     false,
-                    'bg-blue-50 text-blue-700'
+                    'bg-blue-50 text-blue-700',
+                    'bg-gray-100 text-gray-700'
                   )}
                 </Select.Item>
               </Select.Content>

--- a/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
+++ b/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
@@ -89,6 +89,10 @@ export function ExamReviewDetailInfoSection({
 }: ExamReviewDetailInfoSectionProps) {
   const confirmStatus = formData.isConfirmed ? 'CONFIRMED' : 'UNCONFIRMED';
   const deletionStatusLabel = getProcessStatusLabel(formData.deletionStatus);
+  const deletionStatusClassName =
+    formData.deletionStatus === 'USER_DELETED'
+      ? 'border-orange-200 bg-orange-50 text-orange-700'
+      : 'border-red-200 bg-red-50 text-red-700';
   const visibilityStatusLabel = getProcessStatusLabel(
     formData.visibilityStatus
   );
@@ -164,7 +168,7 @@ export function ExamReviewDetailInfoSection({
                 deletionStatusLabel,
                 formData.deletionStatus !== null &&
                   formData.deletionStatus !== 'VISIBLE',
-                'border-red-200 bg-red-50 text-red-700'
+                deletionStatusClassName
               )}
             </div>
           </Field.Content>

--- a/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
+++ b/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
@@ -65,7 +65,7 @@ const renderStatusBadge = (
   label: string,
   isActive: boolean,
   activeClassName: string,
-  inactiveClassName = 'bg-gray-100 text-gray-500'
+  inactiveClassName = 'bg-gray-100 text-gray-700'
 ) => (
   <Badge
     variant='default'
@@ -135,8 +135,7 @@ export function ExamReviewDetailInfoSection({
                 {renderStatusBadge(
                   formData.isDiscussed ? '논의 있음' : '논의 없음',
                   formData.isDiscussed,
-                  'bg-blue-50 text-blue-700',
-                  'bg-gray-100 text-gray-700'
+                  'bg-blue-50 text-blue-700'
                 )}
               </Select.Trigger>
               <Select.Content>
@@ -144,16 +143,14 @@ export function ExamReviewDetailInfoSection({
                   {renderStatusBadge(
                     '논의 있음',
                     true,
-                    'bg-blue-50 text-blue-700',
-                    'bg-gray-100 text-gray-700'
+                    'bg-blue-50 text-blue-700'
                   )}
                 </Select.Item>
                 <Select.Item value='false'>
                   {renderStatusBadge(
                     '논의 없음',
                     false,
-                    'bg-blue-50 text-blue-700',
-                    'bg-gray-100 text-gray-700'
+                    'bg-blue-50 text-blue-700'
                   )}
                 </Select.Item>
               </Select.Content>

--- a/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
+++ b/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
@@ -135,7 +135,7 @@ export function ExamReviewDetailInfoSection({
                 {renderStatusBadge(
                   formData.isDiscussed ? '논의 있음' : '논의 없음',
                   formData.isDiscussed,
-                  'border-blue-200 bg-blue-50 text-blue-700'
+                  'bg-blue-50 text-blue-700'
                 )}
               </Select.Trigger>
               <Select.Content>
@@ -143,14 +143,14 @@ export function ExamReviewDetailInfoSection({
                   {renderStatusBadge(
                     '논의 있음',
                     true,
-                    'border-blue-200 bg-blue-50 text-blue-700'
+                    'bg-blue-50 text-blue-700'
                   )}
                 </Select.Item>
                 <Select.Item value='false'>
                   {renderStatusBadge(
                     '논의 없음',
                     false,
-                    'border-blue-200 bg-blue-50 text-blue-700'
+                    'bg-blue-50 text-blue-700'
                   )}
                 </Select.Item>
               </Select.Content>

--- a/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
+++ b/src/domains/Reviews/components/ExamReviewDetailInfoSection.tsx
@@ -64,13 +64,14 @@ const getProcessStatusLabel = (
 const renderStatusBadge = (
   label: string,
   isActive: boolean,
-  activeClassName: string
+  activeClassName: string,
+  inactiveClassName = 'bg-gray-100 text-gray-500'
 ) => (
   <Badge
-    variant='outline'
+    variant='default'
     className={cn(
       'max-w-full truncate',
-      isActive ? activeClassName : 'text-gray-500'
+      isActive ? activeClassName : inactiveClassName
     )}
     title={label}
   >
@@ -89,10 +90,6 @@ export function ExamReviewDetailInfoSection({
 }: ExamReviewDetailInfoSectionProps) {
   const confirmStatus = formData.isConfirmed ? 'CONFIRMED' : 'UNCONFIRMED';
   const deletionStatusLabel = getProcessStatusLabel(formData.deletionStatus);
-  const deletionStatusClassName =
-    formData.deletionStatus === 'USER_DELETED'
-      ? 'border-orange-200 bg-orange-50 text-orange-700'
-      : 'border-red-200 bg-red-50 text-red-700';
   const visibilityStatusLabel = getProcessStatusLabel(
     formData.visibilityStatus
   );
@@ -168,7 +165,7 @@ export function ExamReviewDetailInfoSection({
                 deletionStatusLabel,
                 formData.deletionStatus !== null &&
                   formData.deletionStatus !== 'VISIBLE',
-                deletionStatusClassName
+                'bg-red-50 text-red-700'
               )}
             </div>
           </Field.Content>
@@ -179,8 +176,10 @@ export function ExamReviewDetailInfoSection({
             <div className={STATUS_FIELD_CLASS_NAME}>
               {renderStatusBadge(
                 formData.isSanctioned ? '징계' : '징계 없음',
-                formData.isSanctioned,
-                'border-rose-200 bg-rose-50 text-rose-700'
+                true,
+                formData.isSanctioned
+                  ? 'bg-violet-50 text-violet-700'
+                  : 'bg-emerald-50 text-emerald-700'
               )}
             </div>
           </Field.Content>
@@ -193,7 +192,7 @@ export function ExamReviewDetailInfoSection({
                 visibilityStatusLabel,
                 formData.visibilityStatus !== null &&
                   formData.visibilityStatus !== 'VISIBLE',
-                'border-amber-200 bg-amber-50 text-amber-700'
+                'bg-amber-50 text-amber-700'
               )}
             </div>
           </Field.Content>

--- a/src/domains/Reviews/components/ExamReviewProcessStatusBadge.tsx
+++ b/src/domains/Reviews/components/ExamReviewProcessStatusBadge.tsx
@@ -1,0 +1,40 @@
+import { Badge } from '@/shared/components/ui';
+import { cn } from '@/shared/lib';
+
+import type { ExamReviewProcessStatus } from '@/domains/Reviews/types';
+import { getExamReviewProcessStatusLabel } from '@/domains/Reviews/utils';
+
+interface ExamReviewProcessStatusBadgeProps {
+  status: ExamReviewProcessStatus;
+  className?: string;
+}
+
+const PROCESS_STATUS_BADGE_CLASS_NAMES: Record<
+  ExamReviewProcessStatus,
+  string
+> = {
+  VISIBLE: 'bg-gray-100 text-gray-700',
+  USER_DELETED: 'bg-red-50 text-red-700',
+  ADMIN_DELETED: 'bg-red-50 text-red-700',
+  ADMIN_HIDDEN: 'bg-amber-50 text-amber-700',
+  AUTO_HIDDEN: 'bg-amber-50 text-amber-700',
+  SANCTIONED: 'bg-violet-50 text-violet-700',
+  DESANCTIONED: 'bg-emerald-50 text-emerald-700',
+};
+
+export function ExamReviewProcessStatusBadge({
+  status,
+  className,
+}: ExamReviewProcessStatusBadgeProps) {
+  const label = getExamReviewProcessStatusLabel(status);
+
+  return (
+    <Badge
+      variant='default'
+      className={cn(PROCESS_STATUS_BADGE_CLASS_NAMES[status], className)}
+      title={label}
+    >
+      {label}
+    </Badge>
+  );
+}

--- a/src/domains/Reviews/components/ExamSearch.tsx
+++ b/src/domains/Reviews/components/ExamSearch.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { ChevronDown, X } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { Button, Input, Select } from '@/shared/components/ui';
+import { Badge, Button, Input, Select } from '@/shared/components/ui';
 import {
   EXAM_REVIEW_PROCESS_STATUS,
   EXAM_TYPE_LIST,
@@ -91,6 +91,40 @@ const getStatusCodesFromLabels = (statusLabels: string[]): string =>
 const getStatusCodeFromLabel = (statusLabel: string) =>
   EXAM_REVIEW_PROCESS_STATUS.find((status) => status.label === statusLabel)
     ?.code;
+
+const getDiscussionStatusLabel = (status: string) => {
+  if (status === TRUE_SELECTED) {
+    return '논의 있음';
+  }
+
+  if (status === FALSE_SELECTED) {
+    return '논의 없음';
+  }
+
+  return '논의 여부 전체';
+};
+
+const renderDiscussionStatusBadge = (status: string) => {
+  const label = getDiscussionStatusLabel(status);
+
+  if (status === ALL_SELECTED) {
+    return label;
+  }
+
+  return (
+    <Badge
+      variant='default'
+      className={
+        status === TRUE_SELECTED
+          ? 'bg-blue-50 text-blue-700'
+          : 'bg-gray-100 text-gray-500'
+      }
+      title={label}
+    >
+      {label}
+    </Badge>
+  );
+};
 
 export default function ExamSearch({
   onSearchChange,
@@ -466,17 +500,25 @@ export default function ExamSearch({
 
         <Select value={discussionStatus} onValueChange={setDiscussionStatus}>
           <Select.Trigger className='h-9 w-[150px] text-sm'>
-            <Select.Value />
+            {renderDiscussionStatusBadge(discussionStatus)}
           </Select.Trigger>
           <Select.Content align='start'>
             <Select.Item value={ALL_SELECTED} className='text-sm'>
               논의 여부 전체
             </Select.Item>
-            <Select.Item value={TRUE_SELECTED} className='text-sm'>
-              논의 있음
+            <Select.Item
+              value={TRUE_SELECTED}
+              className='text-sm'
+              textValue='논의 있음'
+            >
+              {renderDiscussionStatusBadge(TRUE_SELECTED)}
             </Select.Item>
-            <Select.Item value={FALSE_SELECTED} className='text-sm'>
-              논의 없음
+            <Select.Item
+              value={FALSE_SELECTED}
+              className='text-sm'
+              textValue='논의 없음'
+            >
+              {renderDiscussionStatusBadge(FALSE_SELECTED)}
             </Select.Item>
           </Select.Content>
         </Select>

--- a/src/domains/Reviews/components/ExamSearch.tsx
+++ b/src/domains/Reviews/components/ExamSearch.tsx
@@ -545,8 +545,8 @@ export default function ExamSearch({
           >
             <span className='truncate'>
               {selectedStatuses.length > 0
-                ? `처리 상태 ${selectedStatuses.length}개`
-                : '처리 상태 전체'}
+                ? `관리 상태 ${selectedStatuses.length}개`
+                : '관리 상태 전체'}
             </span>
             <ChevronDown className='size-4 opacity-50' />
           </Button>

--- a/src/domains/Reviews/components/ExamSearch.tsx
+++ b/src/domains/Reviews/components/ExamSearch.tsx
@@ -376,13 +376,7 @@ export default function ExamSearch({
 
       {/* 필터 Select들 */}
       <div className='flex flex-wrap items-center gap-2'>
-        <Select
-          value={sort}
-          onValueChange={(value) => {
-            setSort(value);
-            handleSearchWithParams({ sort: value });
-          }}
-        >
+        <Select value={sort} onValueChange={setSort}>
           <Select.Trigger className='h-9 w-[150px] text-sm'>
             <Select.Value />
           </Select.Trigger>
@@ -402,13 +396,7 @@ export default function ExamSearch({
           </Select.Content>
         </Select>
 
-        <Select
-          value={semester}
-          onValueChange={(value) => {
-            setSemester(value);
-            handleSearchWithParams({ semester: value });
-          }}
-        >
+        <Select value={semester} onValueChange={setSemester}>
           <Select.Trigger className='h-9 w-[150px] text-sm'>
             <Select.Value />
           </Select.Trigger>
@@ -427,13 +415,7 @@ export default function ExamSearch({
           </Select.Content>
         </Select>
 
-        <Select
-          value={examType}
-          onValueChange={(value) => {
-            setExamType(value);
-            handleSearchWithParams({ examType: value });
-          }}
-        >
+        <Select value={examType} onValueChange={setExamType}>
           <Select.Trigger className='h-9 w-[150px] text-sm'>
             <Select.Value />
           </Select.Trigger>
@@ -452,13 +434,7 @@ export default function ExamSearch({
           </Select.Content>
         </Select>
 
-        <Select
-          value={confirmStatus}
-          onValueChange={(value) => {
-            setConfirmStatus(value);
-            handleSearchWithParams({ confirmStatus: value });
-          }}
-        >
+        <Select value={confirmStatus} onValueChange={setConfirmStatus}>
           <Select.Trigger className='h-9 w-[150px] text-sm'>
             <Select.Value />
           </Select.Trigger>
@@ -483,13 +459,7 @@ export default function ExamSearch({
           </Select.Content>
         </Select>
 
-        <Select
-          value={discussionStatus}
-          onValueChange={(value) => {
-            setDiscussionStatus(value);
-            handleSearchWithParams({ discussionStatus: value });
-          }}
-        >
+        <Select value={discussionStatus} onValueChange={setDiscussionStatus}>
           <Select.Trigger className='h-9 w-[150px] text-sm'>
             <Select.Value />
           </Select.Trigger>
@@ -508,10 +478,7 @@ export default function ExamSearch({
 
         <ExamMultiSelect
           value={selectedStatuses}
-          onValueChange={(value) => {
-            setSelectedStatuses(value);
-            handleSearchWithParams({ selectedStatuses: value });
-          }}
+          onValueChange={setSelectedStatuses}
           options={PROCESS_STATUS_OPTIONS}
           contentClassName='w-[190px]'
         >

--- a/src/domains/Reviews/components/ExamSearch.tsx
+++ b/src/domains/Reviews/components/ExamSearch.tsx
@@ -117,7 +117,7 @@ const renderDiscussionStatusBadge = (status: string) => {
       className={
         status === TRUE_SELECTED
           ? 'bg-blue-50 text-blue-700'
-          : 'bg-gray-100 text-gray-500'
+          : 'bg-gray-100 text-gray-700'
       }
       title={label}
     >

--- a/src/domains/Reviews/components/ExamSearch.tsx
+++ b/src/domains/Reviews/components/ExamSearch.tsx
@@ -22,6 +22,7 @@ import {
 
 import { ExamConfirmStatusBadge } from './ExamConfirmStatusBadge';
 import { ExamMultiSelect } from './ExamMultiSelect';
+import { ExamReviewProcessStatusBadge } from './ExamReviewProcessStatusBadge';
 
 interface ExamSearchProps {
   onSearchChange: (params: ExamReviewSearchParams) => void;
@@ -86,6 +87,10 @@ const getStatusCodesFromLabels = (statusLabels: string[]): string =>
     })
     .filter(isDefined)
     .join(',');
+
+const getStatusCodeFromLabel = (statusLabel: string) =>
+  EXAM_REVIEW_PROCESS_STATUS.find((status) => status.label === statusLabel)
+    ?.code;
 
 export default function ExamSearch({
   onSearchChange,
@@ -481,6 +486,15 @@ export default function ExamSearch({
           onValueChange={setSelectedStatuses}
           options={PROCESS_STATUS_OPTIONS}
           contentClassName='w-[190px]'
+          renderOption={(option) => {
+            const statusCode = getStatusCodeFromLabel(option);
+
+            return statusCode ? (
+              <ExamReviewProcessStatusBadge status={statusCode} />
+            ) : (
+              option
+            );
+          }}
         >
           <Button
             type='button'

--- a/src/domains/Reviews/components/ExamTable.tsx
+++ b/src/domains/Reviews/components/ExamTable.tsx
@@ -8,11 +8,11 @@ import {
 } from 'react';
 
 import { Badge, Table } from '@/shared/components/ui';
-import { EXAM_REVIEW_PROCESS_STATUS } from '@/shared/constants';
 import { cn } from '@/shared/lib';
 
 import {
   ExamConfirmStatusBadge,
+  ExamReviewProcessStatusBadge,
   ExamReviewTablePagination,
   ExamTableEmpty,
   ExamTableEmptyRows,
@@ -21,9 +21,9 @@ import {
 import { useExamReviews } from '@/domains/Reviews/hooks';
 import type {
   ExamReview,
-  ExamReviewProcessStatus,
   ExamReviewSearchParams,
 } from '@/domains/Reviews/types';
+import { getExamReviewProcessStatusLabel } from '@/domains/Reviews/utils';
 
 // 페이지네이션 설정
 const ITEMS_PER_PAGE = 10;
@@ -34,23 +34,6 @@ interface ExamReviewTableColumn {
   width?: string;
   render?: (review: ExamReview) => ReactNode;
 }
-
-const PROCESS_STATUS_BADGE_CLASS_NAMES: Record<
-  ExamReviewProcessStatus,
-  string
-> = {
-  VISIBLE: 'bg-gray-100 text-gray-700',
-  USER_DELETED: 'border-orange-200 bg-orange-50 text-orange-700',
-  ADMIN_DELETED: 'border-red-200 bg-red-50 text-red-700',
-  ADMIN_HIDDEN: 'bg-orange-50 text-orange-700',
-  AUTO_HIDDEN: 'bg-amber-50 text-amber-700',
-  SANCTIONED: 'bg-rose-50 text-rose-700',
-  DESANCTIONED: 'bg-emerald-50 text-emerald-700',
-};
-
-const getProcessStatusLabel = (status: ExamReviewProcessStatus): string =>
-  EXAM_REVIEW_PROCESS_STATUS.find((option) => option.code === status)?.label ??
-  status;
 
 const renderBooleanBadge = (
   value: boolean,
@@ -86,7 +69,9 @@ const renderReportedStatusBadge = (review: ExamReview) => {
 };
 
 const renderProcessStatusBadge = (review: ExamReview) => {
-  const statusLabels = review.processStatuses.map(getProcessStatusLabel);
+  const statusLabels = review.processStatuses.map(
+    getExamReviewProcessStatusLabel
+  );
   const reportLabel = review.isReported ? `신고 ${review.reportCount}` : null;
   const label = [reportLabel, ...statusLabels].filter(Boolean).join(', ');
 
@@ -94,13 +79,7 @@ const renderProcessStatusBadge = (review: ExamReview) => {
     <div className='flex flex-wrap gap-1' title={label}>
       {renderReportedStatusBadge(review)}
       {review.processStatuses.map((status) => (
-        <Badge
-          key={status}
-          variant='outline'
-          className={PROCESS_STATUS_BADGE_CLASS_NAMES[status]}
-        >
-          {getProcessStatusLabel(status)}
-        </Badge>
+        <ExamReviewProcessStatusBadge key={status} status={status} />
       ))}
     </div>
   );

--- a/src/domains/Reviews/components/ExamTable.tsx
+++ b/src/domains/Reviews/components/ExamTable.tsx
@@ -40,8 +40,8 @@ const PROCESS_STATUS_BADGE_CLASS_NAMES: Record<
   string
 > = {
   VISIBLE: 'bg-gray-100 text-gray-700',
-  USER_DELETED: 'bg-slate-100 text-slate-700',
-  ADMIN_DELETED: 'bg-red-50 text-red-700',
+  USER_DELETED: 'border-orange-200 bg-orange-50 text-orange-700',
+  ADMIN_DELETED: 'border-red-200 bg-red-50 text-red-700',
   ADMIN_HIDDEN: 'bg-orange-50 text-orange-700',
   AUTO_HIDDEN: 'bg-amber-50 text-amber-700',
   SANCTIONED: 'bg-rose-50 text-rose-700',

--- a/src/domains/Reviews/components/ExamTable.tsx
+++ b/src/domains/Reviews/components/ExamTable.tsx
@@ -44,7 +44,7 @@ const renderBooleanBadge = (
     variant='default'
     className={cn(
       'max-w-full truncate',
-      value ? 'bg-blue-50 text-blue-700' : 'bg-gray-100 text-gray-500'
+      value ? 'bg-blue-50 text-blue-700' : 'bg-gray-100 text-gray-700'
     )}
     title={value ? trueLabel : falseLabel}
   >

--- a/src/domains/Reviews/components/ExamTable.tsx
+++ b/src/domains/Reviews/components/ExamTable.tsx
@@ -41,10 +41,10 @@ const renderBooleanBadge = (
   falseLabel: string
 ) => (
   <Badge
-    variant='outline'
+    variant='default'
     className={cn(
       'max-w-full truncate',
-      value ? 'border-blue-200 bg-blue-50 text-blue-700' : 'text-gray-500'
+      value ? 'bg-blue-50 text-blue-700' : 'bg-gray-100 text-gray-500'
     )}
     title={value ? trueLabel : falseLabel}
   >
@@ -59,8 +59,8 @@ const renderReportedStatusBadge = (review: ExamReview) => {
 
   return (
     <Badge
-      variant='outline'
-      className='max-w-full truncate border-red-200 bg-red-50 text-red-700'
+      variant='default'
+      className='max-w-full truncate bg-red-50 text-red-700'
       title={label}
     >
       {label}

--- a/src/domains/Reviews/components/index.ts
+++ b/src/domains/Reviews/components/index.ts
@@ -12,6 +12,7 @@ export { ExamReviewPeriodListSection } from './ExamReviewPeriodListSection';
 export { ExamReviewPeriodScheduleForm } from './ExamReviewPeriodScheduleForm';
 export { ExamReviewPeriodUpdateConfirmModal } from './ExamReviewPeriodUpdateConfirmModal';
 export { ExamReviewPostInfoSection } from './ExamReviewPostInfoSection';
+export { ExamReviewProcessStatusBadge } from './ExamReviewProcessStatusBadge';
 export { ExamReviewTablePagination } from './ExamReviewTablePagination';
 export { ExamReviewUpdateConfirmModal } from './ExamReviewUpdateConfirmModal';
 export { default as ExamSearch } from './ExamSearch';

--- a/src/domains/Reviews/utils/exam-formatters.ts
+++ b/src/domains/Reviews/utils/exam-formatters.ts
@@ -29,6 +29,12 @@ const STATUS_LABELS: Record<string, string> = {
   ),
 };
 
+export const getExamReviewProcessStatusLabel = (
+  status: ExamReviewProcessStatus
+): string =>
+  EXAM_REVIEW_PROCESS_STATUS.find((option) => option.code === status)?.label ??
+  status;
+
 const SEMESTER_LABELS: Record<string, string> = {
   FIRST: '1학기',
   SECOND: '2학기',

--- a/src/domains/Reviews/utils/index.ts
+++ b/src/domains/Reviews/utils/index.ts
@@ -7,6 +7,7 @@ export {
   extractYearFromSemester,
   formatExamReviewLogValue,
   getExamReviewProcessStatuses,
+  getExamReviewProcessStatusLabel,
   getStatusName,
   isExamReviewSanctioned,
 } from './exam-formatters';


### PR DESCRIPTION
## 🔎 What is this PR?

Close #354

## 🎯 변경 사항

###### 주요 변경점을 설명해주세요.

- 시험후기 드롭다운 필터 선택 시 자동 목록 갱신 방지
- 신고 있음 체크박스 및 검색어 X 초기화의 즉시 조회 유지
- 시험후기 관리 상태 배지 공통 컴포넌트화
- 검색, 목록, 상세 화면의 상태 배지 문구 및 색상 정리

## 📸 스크린샷 (선택 사항)

| Before | After |
| :----: | :---: |
|<img width="2940" height="1670" alt="image" src="https://github.com/user-attachments/assets/a7534e60-32d7-4e37-a793-38e4a327efbd" />  | <img width="2940" height="1670" alt="image" src="https://github.com/user-attachments/assets/da532192-c82e-4e10-9ee9-0c8f96637150" /> |

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)

- 드롭다운 필터와 즉시 조회 예외 동작 분리 여부
- 관리 상태 및 논의 상태 배지의 화면 간 문구와 색상 일관성