### PR TITLE
feat: 푸시 알림 전송 기능 개선

### DIFF
--- a/src/domains/Alerts/components/PushNotificationConfirmModal.tsx
+++ b/src/domains/Alerts/components/PushNotificationConfirmModal.tsx
@@ -69,17 +69,25 @@ export function PushNotificationConfirmModal({
           ))}
         </div>
 
-        <Dialog.Footer>
+        <Dialog.Footer className='grid grid-cols-2 gap-3 sm:grid sm:grid-cols-2 sm:justify-normal'>
           <Button
             type='button'
             variant='outline'
+            size='lg'
             disabled={isLoading}
             onClick={onClose}
+            className='w-full'
           >
             취소
           </Button>
-          <Button type='button' disabled={isLoading} onClick={onConfirm}>
-            확인
+          <Button
+            type='button'
+            size='lg'
+            disabled={isLoading}
+            onClick={onConfirm}
+            className='w-full'
+          >
+            {isLoading ? '발송 중...' : '즉시 발송'}
           </Button>
         </Dialog.Footer>
       </Dialog.Content>

--- a/src/domains/Alerts/components/PushNotificationConfirmModal.tsx
+++ b/src/domains/Alerts/components/PushNotificationConfirmModal.tsx
@@ -5,6 +5,7 @@ import type { PushNotification } from '@/shared/types';
 
 interface PushNotificationConfirmModalProps {
   isOpen: boolean;
+  isLoading: boolean;
   onClose: () => void;
   onConfirm: () => void;
   data: PushNotification;
@@ -12,6 +13,7 @@ interface PushNotificationConfirmModalProps {
 
 export function PushNotificationConfirmModal({
   isOpen,
+  isLoading,
   onClose,
   onConfirm,
   data,
@@ -41,8 +43,15 @@ export function PushNotificationConfirmModal({
   );
 
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <Dialog.Content>
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open && !isLoading) {
+          onClose();
+        }
+      }}
+    >
+      <Dialog.Content showCloseButton={!isLoading}>
         <Dialog.Header>
           <Dialog.Title>푸시 알림 전송 확인</Dialog.Title>
           <Dialog.Description>
@@ -61,10 +70,15 @@ export function PushNotificationConfirmModal({
         </div>
 
         <Dialog.Footer>
-          <Button type='button' variant='outline' onClick={onClose}>
+          <Button
+            type='button'
+            variant='outline'
+            disabled={isLoading}
+            onClick={onClose}
+          >
             취소
           </Button>
-          <Button type='button' onClick={onConfirm}>
+          <Button type='button' disabled={isLoading} onClick={onConfirm}>
             확인
           </Button>
         </Dialog.Footer>

--- a/src/domains/Alerts/components/PushNotificationConfirmModal.tsx
+++ b/src/domains/Alerts/components/PushNotificationConfirmModal.tsx
@@ -23,6 +23,10 @@ export function PushNotificationConfirmModal({
       { label: '알림 내용', value: data.body },
       { label: 'URL', value: data.url },
       {
+        label: 'URL 타입',
+        value: data.isExternal ? '외부 URL' : '스노로즈 내부 URL',
+      },
+      {
         label: '메시지 유형',
         value: data.isMarketing ? '광고성' : '정보성',
       },

--- a/src/pages/alerts/PushNotificationPage.test.tsx
+++ b/src/pages/alerts/PushNotificationPage.test.tsx
@@ -353,6 +353,7 @@ describe('PushNotificationPage', () => {
         url: '/',
         isMarketing: true,
         isTest: true,
+        isExternal: false,
       });
     });
 
@@ -459,6 +460,53 @@ describe('PushNotificationPage', () => {
         url: '/board/notice/post/123',
         isMarketing: false,
         isTest: false,
+        isExternal: false,
+      });
+    });
+  });
+
+  test('외부 URL 선택 후 확인하면 isExternal true로 전달된다', async () => {
+    vi.mocked(postPushNotificationAPI).mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(<PushNotificationPage />);
+
+    const nameInput = screen.getByLabelText(/알림명/);
+    const titleInput = screen.getByLabelText(/알림 제목/);
+    const bodyInput = screen.getByLabelText(/알림 내용/);
+    const urlInput = screen.getByLabelText(/알림 클릭 시 연결되는 주소/);
+
+    await user.click(screen.getByLabelText(/외부 URL/));
+
+    await user.type(nameInput, '리뉴얼 포인트 지급 안내');
+    await user.type(titleInput, '리뉴얼 포인트');
+    await user.type(bodyInput, '10포인트 지급 안내입니다.');
+    await user.clear(urlInput);
+    await user.type(urlInput, 'https://www.snorose.com/point/history');
+
+    await user.click(
+      screen.getByLabelText(
+        /정보성 \(전체 공지, 댓글, 관리자 삭제\/비공개 통보 등\)/
+      )
+    );
+    await user.click(
+      screen.getByLabelText(/푸시 알림 허용 회원 전체에게 발송/)
+    );
+
+    const applyButton = screen.getByRole('button', { name: '알림 전송' });
+    await user.click(applyButton);
+
+    const confirmButton = screen.getByRole('button', { name: '확인' });
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(postPushNotificationAPI).toHaveBeenCalledWith({
+        name: '리뉴얼 포인트 지급 안내',
+        title: '리뉴얼 포인트',
+        body: '10포인트 지급 안내입니다.',
+        url: 'https://www.snorose.com/point/history',
+        isMarketing: false,
+        isTest: false,
+        isExternal: true,
       });
     });
   });
@@ -617,6 +665,7 @@ describe('PushNotificationPage', () => {
         expect(postPushNotificationAPI).toHaveBeenCalledWith(
           expect.objectContaining({
             url: '/board/notice?page=1&id=123',
+            isExternal: false,
           })
         );
       });
@@ -711,10 +760,11 @@ describe('PushNotificationPage', () => {
     });
 
     test.each([
-      ['https', 'https://www.snorose.com/board/notice/post/1869958'],
-      ['http', 'http://www.snorose.com/board/notice/post/1869958'],
+      ['base URL', 'https://www.snorose.com'],
+      ['https 전체 URL', 'https://www.snorose.com/board/notice/post/1869958'],
+      ['http 전체 URL', 'http://www.snorose.com/board/notice/post/1869958'],
     ])(
-      '내부 URL 모드에서 스노로즈 전체(%s) 주소를 입력하면 토스트만 뜨고 모달은 열리지 않는다',
+      '내부 URL 모드에서 스노로즈 %s를 입력하면 토스트만 뜨고 모달은 열리지 않는다',
       async (_, url) => {
         const user = userEvent.setup();
         render(<PushNotificationPage />);
@@ -729,6 +779,8 @@ describe('PushNotificationPage', () => {
         await user.type(bodyInput, '테스트 내용');
         await user.clear(urlInput);
         await user.type(urlInput, url);
+
+        expect(screen.getByLabelText(/스노로즈 내부 URL/)).toBeChecked();
 
         const applyButton = screen.getByRole('button', { name: '알림 전송' });
         await user.click(applyButton);
@@ -777,12 +829,13 @@ describe('PushNotificationPage', () => {
         expect(postPushNotificationAPI).toHaveBeenCalledWith(
           expect.objectContaining({
             url: 'https://www.snorose.com/board/notice/post/1869958',
+            isExternal: true,
           })
         );
       });
     });
 
-    test('외부 URL 모드에서 스노로즈 전체(http) 주소를 입력하면 모달이 열리고 API 호출 시 그대로 전달된다', async () => {
+    test('외부 URL 모드에서 스노로즈 전체(http) 주소를 입력하면 https로 변환되어 전달된다', async () => {
       vi.mocked(postPushNotificationAPI).mockResolvedValue(undefined);
       const user = userEvent.setup();
       render(<PushNotificationPage />);
@@ -807,6 +860,10 @@ describe('PushNotificationPage', () => {
       await user.click(applyButton);
 
       expect(screen.getByTestId('confirm-modal')).toBeInTheDocument();
+      const modalUrl = screen.getByTestId('modal-url');
+      expect(modalUrl).toHaveTextContent(
+        'URL: https://www.snorose.com/board/notice/post/1869958'
+      );
 
       const confirmButton = screen.getByRole('button', { name: '확인' });
       await user.click(confirmButton);
@@ -814,7 +871,46 @@ describe('PushNotificationPage', () => {
       await waitFor(() => {
         expect(postPushNotificationAPI).toHaveBeenCalledWith(
           expect.objectContaining({
-            url: 'http://www.snorose.com/board/notice/post/1869958',
+            url: 'https://www.snorose.com/board/notice/post/1869958',
+            isExternal: true,
+          })
+        );
+      });
+    });
+
+    test('외부 URL 모드에서 프로토콜 없이 입력하면 https를 붙여 전달된다', async () => {
+      vi.mocked(postPushNotificationAPI).mockResolvedValue(undefined);
+      const user = userEvent.setup();
+      render(<PushNotificationPage />);
+
+      const nameInput = screen.getByLabelText(/알림명/);
+      const titleInput = screen.getByLabelText(/알림 제목/);
+      const bodyInput = screen.getByLabelText(/알림 내용/);
+      const urlInput = screen.getByLabelText(/알림 클릭 시 연결되는 주소/);
+
+      await user.click(screen.getByLabelText(/외부 URL/));
+
+      await user.type(nameInput, '테스트 알림');
+      await user.type(titleInput, '테스트 제목');
+      await user.type(bodyInput, '테스트 내용');
+      await user.clear(urlInput);
+      await user.type(urlInput, 'example.com/some/path');
+
+      const applyButton = screen.getByRole('button', { name: '알림 전송' });
+      await user.click(applyButton);
+
+      expect(screen.getByTestId('confirm-modal')).toBeInTheDocument();
+      const modalUrl = screen.getByTestId('modal-url');
+      expect(modalUrl).toHaveTextContent('URL: https://example.com/some/path');
+
+      const confirmButton = screen.getByRole('button', { name: '확인' });
+      await user.click(confirmButton);
+
+      await waitFor(() => {
+        expect(postPushNotificationAPI).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: 'https://example.com/some/path',
+            isExternal: true,
           })
         );
       });
@@ -834,6 +930,8 @@ describe('PushNotificationPage', () => {
       await user.type(bodyInput, '테스트 내용');
       await user.clear(urlInput);
       await user.type(urlInput, 'https://example.com/some/path');
+
+      expect(screen.getByLabelText(/스노로즈 내부 URL/)).toBeChecked();
 
       const applyButton = screen.getByRole('button', { name: '알림 전송' });
       await user.click(applyButton);
@@ -924,6 +1022,7 @@ describe('PushNotificationPage', () => {
           url: '/',
           isMarketing: true,
           isTest: true,
+          isExternal: false,
         });
       });
     });

--- a/src/pages/alerts/PushNotificationPage.test.tsx
+++ b/src/pages/alerts/PushNotificationPage.test.tsx
@@ -51,7 +51,7 @@ vi.mock('@/domains/Alerts/components', () => ({
           취소
         </button>
         <button disabled={isLoading} onClick={onConfirm}>
-          확인
+          {isLoading ? '발송 중...' : '즉시 발송'}
         </button>
       </div>
     );
@@ -348,7 +348,7 @@ describe('PushNotificationPage', () => {
     const applyButton = screen.getByRole('button', { name: '알림 전송' });
     await user.click(applyButton);
 
-    const confirmButton = screen.getByRole('button', { name: '확인' });
+    const confirmButton = screen.getByRole('button', { name: '즉시 발송' });
     await user.click(confirmButton);
 
     await waitFor(() => {
@@ -388,7 +388,7 @@ describe('PushNotificationPage', () => {
     const applyButton = screen.getByRole('button', { name: '알림 전송' });
     await user.click(applyButton);
 
-    const confirmButton = screen.getByRole('button', { name: '확인' });
+    const confirmButton = screen.getByRole('button', { name: '즉시 발송' });
     await user.click(confirmButton);
 
     await waitFor(() => {
@@ -415,7 +415,7 @@ describe('PushNotificationPage', () => {
     const applyButton = screen.getByRole('button', { name: '알림 전송' });
     await user.click(applyButton);
 
-    const confirmButton = screen.getByRole('button', { name: '확인' });
+    const confirmButton = screen.getByRole('button', { name: '즉시 발송' });
     await user.click(confirmButton);
 
     await waitFor(() => {
@@ -455,7 +455,7 @@ describe('PushNotificationPage', () => {
     const applyButton = screen.getByRole('button', { name: '알림 전송' });
     await user.click(applyButton);
 
-    const confirmButton = screen.getByRole('button', { name: '확인' });
+    const confirmButton = screen.getByRole('button', { name: '즉시 발송' });
     await user.click(confirmButton);
 
     await waitFor(() => {
@@ -501,7 +501,7 @@ describe('PushNotificationPage', () => {
     const applyButton = screen.getByRole('button', { name: '알림 전송' });
     await user.click(applyButton);
 
-    const confirmButton = screen.getByRole('button', { name: '확인' });
+    const confirmButton = screen.getByRole('button', { name: '즉시 발송' });
     await user.click(confirmButton);
 
     await waitFor(() => {
@@ -664,7 +664,7 @@ describe('PushNotificationPage', () => {
       const applyButton = screen.getByRole('button', { name: '알림 전송' });
       await user.click(applyButton);
 
-      const confirmButton = screen.getByRole('button', { name: '확인' });
+      const confirmButton = screen.getByRole('button', { name: '즉시 발송' });
       await user.click(confirmButton);
 
       await waitFor(() => {
@@ -744,11 +744,13 @@ describe('PushNotificationPage', () => {
       const applyButton = screen.getByRole('button', { name: '알림 전송' });
       await user.click(applyButton);
 
-      const confirmButton = screen.getByRole('button', { name: '확인' });
+      const confirmButton = screen.getByRole('button', { name: '즉시 발송' });
       await user.click(confirmButton);
 
       await waitFor(() => {
-        expect(confirmButton).toBeDisabled();
+        expect(
+          screen.getByRole('button', { name: '발송 중...' })
+        ).toBeDisabled();
       });
 
       // API 호출 중에 다시 클릭 시도
@@ -851,7 +853,7 @@ describe('PushNotificationPage', () => {
         'URL: https://www.snorose.com/board/notice/post/1869958'
       );
 
-      const confirmButton = screen.getByRole('button', { name: '확인' });
+      const confirmButton = screen.getByRole('button', { name: '즉시 발송' });
       await user.click(confirmButton);
 
       await waitFor(() => {
@@ -894,7 +896,7 @@ describe('PushNotificationPage', () => {
         'URL: https://www.snorose.com/board/notice/post/1869958'
       );
 
-      const confirmButton = screen.getByRole('button', { name: '확인' });
+      const confirmButton = screen.getByRole('button', { name: '즉시 발송' });
       await user.click(confirmButton);
 
       await waitFor(() => {
@@ -958,7 +960,7 @@ describe('PushNotificationPage', () => {
       const modalUrl = screen.getByTestId('modal-url');
       expect(modalUrl).toHaveTextContent('URL: https://example.com/some/path');
 
-      const confirmButton = screen.getByRole('button', { name: '확인' });
+      const confirmButton = screen.getByRole('button', { name: '즉시 발송' });
       await user.click(confirmButton);
 
       await waitFor(() => {
@@ -1065,7 +1067,7 @@ describe('PushNotificationPage', () => {
       const applyButton = screen.getByRole('button', { name: '알림 전송' });
       await user.click(applyButton);
 
-      const confirmButton = screen.getByRole('button', { name: '확인' });
+      const confirmButton = screen.getByRole('button', { name: '즉시 발송' });
       await user.click(confirmButton);
 
       // API 호출 시 URL이 절대 경로로 전달되어야 함

--- a/src/pages/alerts/PushNotificationPage.test.tsx
+++ b/src/pages/alerts/PushNotificationPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { toast } from 'sonner';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -28,11 +28,13 @@ vi.mock('@/shared/utils', () => ({
 vi.mock('@/domains/Alerts/components', () => ({
   PushNotificationConfirmModal: ({
     isOpen,
+    isLoading,
     onClose,
     onConfirm,
     data,
   }: {
     isOpen: boolean;
+    isLoading: boolean;
     onClose: () => void;
     onConfirm: () => void;
     data: PushNotification;
@@ -45,8 +47,12 @@ vi.mock('@/domains/Alerts/components', () => ({
         <div>알림 제목: {data.title}</div>
         <div>알림 내용: {data.body}</div>
         <div data-testid='modal-url'>URL: {data.url}</div>
-        <button onClick={onClose}>취소</button>
-        <button onClick={onConfirm}>확인</button>
+        <button disabled={isLoading} onClick={onClose}>
+          취소
+        </button>
+        <button disabled={isLoading} onClick={onConfirm}>
+          확인
+        </button>
       </div>
     );
   },
@@ -741,6 +747,10 @@ describe('PushNotificationPage', () => {
       const confirmButton = screen.getByRole('button', { name: '확인' });
       await user.click(confirmButton);
 
+      await waitFor(() => {
+        expect(confirmButton).toBeDisabled();
+      });
+
       // API 호출 중에 다시 클릭 시도
       await user.click(confirmButton);
 
@@ -748,8 +758,10 @@ describe('PushNotificationPage', () => {
       expect(postPushNotificationAPI).toHaveBeenCalledTimes(1);
 
       // Promise 해결
-      resolvePromise!(undefined);
-      await promise;
+      await act(async () => {
+        resolvePromise!(undefined);
+        await promise;
+      });
     });
 
     test('URL 입력 타입 기본값은 스노로즈 내부 URL이다', () => {

--- a/src/pages/alerts/PushNotificationPage.test.tsx
+++ b/src/pages/alerts/PushNotificationPage.test.tsx
@@ -759,6 +759,23 @@ describe('PushNotificationPage', () => {
       expect(internalUrlRadio).toBeChecked();
     });
 
+    test('URL 타입을 변경해도 입력한 URL은 유지된다', async () => {
+      const user = userEvent.setup();
+      render(<PushNotificationPage />);
+
+      const urlInput = screen.getByLabelText(/알림 클릭 시 연결되는 주소/);
+
+      await user.clear(urlInput);
+      await user.type(urlInput, '/board/notice/post/123');
+      await user.click(screen.getByLabelText(/외부 URL/));
+
+      expect(urlInput).toHaveValue('/board/notice/post/123');
+
+      await user.click(screen.getByLabelText(/스노로즈 내부 URL/));
+
+      expect(urlInput).toHaveValue('/board/notice/post/123');
+    });
+
     test.each([
       ['base URL', 'https://www.snorose.com'],
       ['https 전체 URL', 'https://www.snorose.com/board/notice/post/1869958'],
@@ -876,6 +893,32 @@ describe('PushNotificationPage', () => {
           })
         );
       });
+    });
+
+    test('외부 URL 모드에서 내부 경로를 입력하면 토스트만 뜨고 모달은 열리지 않는다', async () => {
+      const user = userEvent.setup();
+      render(<PushNotificationPage />);
+
+      const nameInput = screen.getByLabelText(/알림명/);
+      const titleInput = screen.getByLabelText(/알림 제목/);
+      const bodyInput = screen.getByLabelText(/알림 내용/);
+      const urlInput = screen.getByLabelText(/알림 클릭 시 연결되는 주소/);
+
+      await user.type(nameInput, '테스트 알림');
+      await user.type(titleInput, '테스트 제목');
+      await user.type(bodyInput, '테스트 내용');
+      await user.clear(urlInput);
+      await user.type(urlInput, '/board/notice/post/123');
+      await user.click(screen.getByLabelText(/외부 URL/));
+
+      const applyButton = screen.getByRole('button', { name: '알림 전송' });
+      await user.click(applyButton);
+
+      expect(toast.info).toHaveBeenCalledWith(
+        '외부 URL은 도메인을 포함한 주소를 입력해 주세요. (예: https://example.com)'
+      );
+      expect(urlInput).toHaveValue('/board/notice/post/123');
+      expect(screen.queryByTestId('confirm-modal')).not.toBeInTheDocument();
     });
 
     test('외부 URL 모드에서 프로토콜 없이 입력하면 https를 붙여 전달된다', async () => {

--- a/src/pages/alerts/PushNotificationPage.tsx
+++ b/src/pages/alerts/PushNotificationPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { toast } from 'sonner';
 
@@ -92,6 +92,7 @@ export default function PushNotificationPage() {
   const [formData, setFormData] = useState<PushNotification>(INITIAL_FORM_DATA);
   const [isLoading, setIsLoading] = useState(false);
   const [urlInputType, setUrlInputType] = useState<UrlInputType>('internal');
+  const isSubmittingRef = useRef(false);
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFormData({
@@ -193,11 +194,20 @@ export default function PushNotificationPage() {
     setIsOpen(true);
   };
 
-  const handleConfirmModalButtonClick = async () => {
+  const handleConfirmModalClose = () => {
     if (isLoading) {
       return;
     }
 
+    setIsOpen(false);
+  };
+
+  const handleConfirmModalButtonClick = async () => {
+    if (isSubmittingRef.current) {
+      return;
+    }
+
+    isSubmittingRef.current = true;
     setIsLoading(true);
     try {
       await postPushNotificationAPI(toPushApiData(formData, urlInputType));
@@ -206,6 +216,7 @@ export default function PushNotificationPage() {
     } catch (error: unknown) {
       toast.error(getErrorMessage(error, '푸시 알림 전송에 실패했어요.'));
     } finally {
+      isSubmittingRef.current = false;
       setIsLoading(false);
       setIsOpen(false);
     }
@@ -408,7 +419,8 @@ export default function PushNotificationPage() {
 
       <PushNotificationConfirmModal
         isOpen={isOpen}
-        onClose={() => setIsOpen(false)}
+        isLoading={isLoading}
+        onClose={handleConfirmModalClose}
         onConfirm={handleConfirmModalButtonClick}
         data={toPushApiData(formData, urlInputType)}
       />

--- a/src/pages/alerts/PushNotificationPage.tsx
+++ b/src/pages/alerts/PushNotificationPage.tsx
@@ -20,10 +20,14 @@ import { postPushNotificationAPI } from '@/apis';
 /** 알림 링크: 스노로즈 내부(경로만) vs 외부(전체 URL) */
 type UrlInputType = 'internal' | 'external';
 
+function isHttpUrl(url: string): boolean {
+  return url.startsWith('http://') || url.startsWith('https://');
+}
+
 /** 내부 URL 모드에서 도메인까지 붙여 입력한 경우 (경로만 보내야 함) */
 function isSnoroseSiteAbsoluteUrl(url: string): boolean {
   const trimmed = url.trim();
-  if (!trimmed.startsWith('http://') && !trimmed.startsWith('https://')) {
+  if (!isHttpUrl(trimmed)) {
     return false;
   }
   try {
@@ -37,20 +41,40 @@ function isSnoroseSiteAbsoluteUrl(url: string): boolean {
 /**
  * API로 보낼 `url` 필드.
  * 내부: 경로만 보낸다. 기본 도메인은 서버에서 붙인다.
- * 외부: 입력한 http(s) URL 전체를 그대로 보낸다.
+ * 외부: 항상 https://로 시작하는 전체 URL을 보낸다.
  */
 function toPushApiUrl(url: string, urlInputType: UrlInputType): string {
   const trimmed = (url ?? '').trim();
   if (urlInputType === 'external') {
-    return trimmed;
+    if (trimmed === '') {
+      return '';
+    }
+    if (trimmed.startsWith('https://')) {
+      return trimmed;
+    }
+    if (trimmed.startsWith('http://')) {
+      return `https://${trimmed.slice('http://'.length)}`;
+    }
+    return `https://${trimmed}`;
   }
-  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+  if (isHttpUrl(trimmed)) {
     return trimmed;
   }
   if (trimmed === '') {
     return '/';
   }
   return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+}
+
+function toPushApiData(
+  data: PushNotification,
+  urlInputType: UrlInputType
+): PushNotification {
+  return {
+    ...data,
+    url: toPushApiUrl(data.url ?? '', urlInputType),
+    isExternal: urlInputType === 'external',
+  };
 }
 
 const INITIAL_FORM_DATA: PushNotification = {
@@ -60,6 +84,7 @@ const INITIAL_FORM_DATA: PushNotification = {
   url: '',
   isMarketing: true,
   isTest: true,
+  isExternal: false,
 };
 
 export default function PushNotificationPage() {
@@ -88,12 +113,23 @@ export default function PushNotificationPage() {
   };
 
   const handleUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFormData({ ...formData, url: e.target.value });
+    const nextUrl = e.target.value;
+
+    setFormData({
+      ...formData,
+      url: nextUrl,
+      isExternal: urlInputType === 'external',
+    });
   };
 
   const handleUrlInputTypeChange = (selectedUrlType: string) => {
-    setUrlInputType(selectedUrlType as UrlInputType);
-    setFormData((prev) => ({ ...prev, url: '' }));
+    const nextUrlInputType = selectedUrlType as UrlInputType;
+    setUrlInputType(nextUrlInputType);
+    setFormData((prev) => ({
+      ...prev,
+      url: '',
+      isExternal: nextUrlInputType === 'external',
+    }));
   };
 
   const handleApplyButtonClick = () => {
@@ -115,9 +151,7 @@ export default function PushNotificationPage() {
         );
         return;
       }
-      const isHttpUrl =
-        urlToCheck.startsWith('http://') || urlToCheck.startsWith('https://');
-      if (isHttpUrl) {
+      if (isHttpUrl(urlToCheck)) {
         toast.info(
           '내부 URL 모드에서는 경로만 입력할 수 있습니다. (예: /board/notice)'
         );
@@ -130,12 +164,21 @@ export default function PushNotificationPage() {
         return;
       }
     } else {
-      if (
-        !urlToCheck.startsWith('http://') &&
-        !urlToCheck.startsWith('https://')
-      ) {
+      const httpsExternalUrl = toPushApiUrl(formData.url ?? '', urlInputType);
+
+      if (httpsExternalUrl === '') {
+        toast.info('외부 URL을 입력해 주세요.');
+        return;
+      }
+
+      try {
+        const { protocol, hostname } = new URL(httpsExternalUrl);
+        if (protocol !== 'https:' || !hostname) {
+          throw new Error('Invalid external URL');
+        }
+      } catch {
         toast.info(
-          '외부 URL은 http:// 또는 https://로 시작하는 전체 주소를 입력해 주세요.'
+          '외부 URL은 도메인을 포함한 주소를 입력해 주세요. (예: https://example.com)'
         );
         return;
       }
@@ -151,10 +194,7 @@ export default function PushNotificationPage() {
 
     setIsLoading(true);
     try {
-      await postPushNotificationAPI({
-        ...formData,
-        url: toPushApiUrl(formData.url ?? '', urlInputType),
-      });
+      await postPushNotificationAPI(toPushApiData(formData, urlInputType));
       toast.success('푸시 알림 전송이 완료되었어요.');
       handleResetButtonClick();
     } catch (error: unknown) {
@@ -277,7 +317,7 @@ export default function PushNotificationPage() {
                     주세요.
                   </>
                 ) : (
-                  '전체 URL을 입력해 주세요.'
+                  '전송 시 https://로 시작하는 전체 URL로 전달돼요.'
                 )}
               </p>
             </div>
@@ -364,10 +404,7 @@ export default function PushNotificationPage() {
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
         onConfirm={handleConfirmModalButtonClick}
-        data={{
-          ...formData,
-          url: toPushApiUrl(formData.url ?? '', urlInputType),
-        }}
+        data={toPushApiData(formData, urlInputType)}
       />
 
       <div className='flex justify-end gap-2'>

--- a/src/pages/alerts/PushNotificationPage.tsx
+++ b/src/pages/alerts/PushNotificationPage.tsx
@@ -127,7 +127,6 @@ export default function PushNotificationPage() {
     setUrlInputType(nextUrlInputType);
     setFormData((prev) => ({
       ...prev,
-      url: '',
       isExternal: nextUrlInputType === 'external',
     }));
   };
@@ -164,6 +163,13 @@ export default function PushNotificationPage() {
         return;
       }
     } else {
+      if (urlToCheck.startsWith('/')) {
+        toast.info(
+          '외부 URL은 도메인을 포함한 주소를 입력해 주세요. (예: https://example.com)'
+        );
+        return;
+      }
+
       const httpsExternalUrl = toPushApiUrl(formData.url ?? '', urlInputType);
 
       if (httpsExternalUrl === '') {

--- a/src/shared/constants/sidebar-menus.ts
+++ b/src/shared/constants/sidebar-menus.ts
@@ -1,10 +1,10 @@
 import {
-  // Bell,
   BookOpen,
   FileText,
   HandCoins,
   type LucideIcon,
   MessageSquareWarning,
+  Settings,
   User,
 } from 'lucide-react';
 
@@ -97,26 +97,14 @@ export const SIDEBAR_MENUS: SidebarMenu[] = [
       },
     ],
   },
-  // {
-  //   title: '알림',
-  //   icon: Bell,
-  //   items: [
-  //     {
-  //       title: '푸시 알림 전송',
-  //       url: '/alerts',
-  //     },
-  //     //     // {
-  //     //     //   title: '이벤트 관리',
-  //     //     //   url: '/operation/event',
-  //     //     // },
-  //     //     // {
-  //     //     //   title: '팝업 관리',
-  //     //     //   url: '/operation/popup',
-  //     //     // },
-  //     //     // {
-  //     //     //   title: '배너 관리',
-  //     //     //   url: '/operation/banner',
-  //     //     // },
-  //   ],
-  // },
+  {
+    title: '운영',
+    icon: Settings,
+    items: [
+      {
+        title: '푸시 알림 전송',
+        url: PATHS.ALERTS,
+      },
+    ],
+  },
 ];

--- a/src/shared/types/alerts.ts
+++ b/src/shared/types/alerts.ts
@@ -5,4 +5,5 @@ export interface PushNotification {
   url: string;
   isMarketing: boolean;
   isTest: boolean;
+  isExternal: boolean;
 }


### PR DESCRIPTION
## 🔎 What is this PR?

Close #356

## 🎯 변경 사항

###### 주요 변경점을 설명해주세요.

- 운영 메뉴 내 푸시 알림 전송 메뉴 노출
- 푸시 알림 내부/외부 URL 타입 구분
- 외부 URL 전송 시 `isExternal` 구분값 전달
- 외부 URL `https://` 보정 및 내부 경로 입력 검증
- 푸시 알림 전송 중 모달 닫힘 및 중복 요청 방지
- 확인 모달 발송 버튼 로딩 상태 표시

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)

- 내부/외부 URL 변환 규칙과 서버 API 기대값 일치 여부
- `isExternal` 추가 필드와 백엔드 요청 스펙 일치 여부
