### PR TITLE
feat: 게시글 댓글 복구 기능 연동

### DIFF
--- a/src/apis/comments.ts
+++ b/src/apis/comments.ts
@@ -86,6 +86,16 @@ export const deleteComment = async (
   return response.data.result;
 };
 
+// 댓글 복구 api
+export const restoreComment = async (
+  commentId: number
+): Promise<AdminDeleteCommentResult> => {
+  const response = await axiosInstance.patch<
+    BaseResponse<AdminDeleteCommentResult>
+  >(`/v1/admin/comments/${commentId}/restore`);
+  return response.data.result;
+};
+
 // 댓글 일괄 삭제 api
 export const bulkDeleteComments = async (
   commentIds: number[],

--- a/src/apis/posts.ts
+++ b/src/apis/posts.ts
@@ -56,6 +56,16 @@ export const deletePost = async (
   return response.data.result;
 };
 
+// 게시글 복구 api
+export const restorePost = async (
+  postId: number
+): Promise<AdminGetPostResponse> => {
+  const response = await axiosInstance.patch<
+    BaseResponse<AdminGetPostResponse>
+  >(`/v1/admin/posts/${postId}/restore`);
+  return response.data.result;
+};
+
 // 여러 게시글 선택 삭제 api
 export const bulkDeletePosts = async (
   postIds: number[],

--- a/src/domains/Comments/hooks/useCommentTableState.ts
+++ b/src/domains/Comments/hooks/useCommentTableState.ts
@@ -138,9 +138,17 @@ export function useCommentTableState({
   const handleBulkRestore = () => {
     if (selectedIds.length === 0) return;
     restoreComment(selectedIds, {
-      onSuccess: (res) => {
-        toast.success(`${res.length}개의 댓글이 복구되었습니다.`);
-        setSelectedIds([]);
+      onSuccess: ({ restored, restoredIds, failedIds }) => {
+        if (failedIds.length > 0) {
+          toast.warning(
+            `${restored.length}개의 댓글이 복구되었고, ${failedIds.length}개는 실패했습니다.`
+          );
+        } else {
+          toast.success(`${restored.length}개의 댓글이 복구되었습니다.`);
+        }
+
+        const restoredIdSet = new Set(restoredIds);
+        setSelectedIds((prev) => prev.filter((id) => !restoredIdSet.has(id)));
         void refetch();
       },
       onError: () => toast.error('댓글 복구 중 오류가 발생했습니다.'),

--- a/src/domains/Comments/hooks/useCommentTableState.ts
+++ b/src/domains/Comments/hooks/useCommentTableState.ts
@@ -8,6 +8,7 @@ import type { AdminCommentResult } from '../types/comment';
 import { useBulkDeleteComment } from './useBulkDeleteComment';
 import { useCommentChildrenList } from './useCommentChildrenList';
 import { useCommentList } from './useCommentList';
+import { useRestoreComment } from './useRestoreComment';
 import { useUpdateCommentVisibility } from './useUpdateCommentVisibility';
 
 interface UseCommentTableStateProps {
@@ -77,6 +78,8 @@ export function useCommentTableState({
 
   const { mutate: bulkDelete, isPending: isDeletePending } =
     useBulkDeleteComment();
+  const { mutate: restoreComment, isPending: isRestorePending } =
+    useRestoreComment();
   const { mutate: bulkVisibility, isPending: isVisibilityPending } =
     useUpdateCommentVisibility();
 
@@ -133,25 +136,15 @@ export function useCommentTableState({
   };
 
   const handleBulkRestore = () => {
-    // TODO: 추후 API 연동 완료 시 아래 플래그를 true로 변경하거나 블록 삭제
-    const IS_READY = false;
-    if (!IS_READY) {
-      toast.info('개발 중입니다.');
-      return;
-    }
-
     if (selectedIds.length === 0) return;
-    bulkVisibility(
-      { commentIds: selectedIds, isVisible: true },
-      {
-        onSuccess: () => {
-          toast.success('선택한 댓글이 성공적으로 복구되었습니다.');
-          setSelectedIds([]);
-          void refetch();
-        },
-        onError: () => toast.error('댓글 복구 중 오류가 발생했습니다.'),
-      }
-    );
+    restoreComment(selectedIds, {
+      onSuccess: (res) => {
+        toast.success(`${res.length}개의 댓글이 복구되었습니다.`);
+        setSelectedIds([]);
+        void refetch();
+      },
+      onError: () => toast.error('댓글 복구 중 오류가 발생했습니다.'),
+    });
   };
 
   // 체크박스 제어
@@ -237,7 +230,7 @@ export function useCommentTableState({
     handleBulkVisibility,
     handleBulkRestore,
     isDeletePending,
-    isVisibilityPending,
+    isVisibilityPending: isVisibilityPending || isRestorePending,
     hasNext,
     totalCount,
   };

--- a/src/domains/Comments/hooks/useRestoreComment.ts
+++ b/src/domains/Comments/hooks/useRestoreComment.ts
@@ -2,12 +2,45 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { restoreComment } from '@/apis';
 
+import type { AdminDeleteCommentResult } from '../types/comment';
+
+interface RestoreCommentResult {
+  restored: AdminDeleteCommentResult[];
+  restoredIds: number[];
+  failedIds: number[];
+}
+
 export const useRestoreComment = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (commentIds: number[]) =>
-      Promise.all(commentIds.map((commentId) => restoreComment(commentId))),
+    mutationFn: async (commentIds: number[]): Promise<RestoreCommentResult> => {
+      const results = await Promise.allSettled(
+        commentIds.map((commentId) => restoreComment(commentId))
+      );
+
+      const restored: AdminDeleteCommentResult[] = [];
+      const restoredIds: number[] = [];
+      const failedIds: number[] = [];
+
+      results.forEach((result, index) => {
+        const commentId = commentIds[index];
+
+        if (result.status === 'fulfilled') {
+          restored.push(result.value);
+          restoredIds.push(commentId);
+          return;
+        }
+
+        failedIds.push(commentId);
+      });
+
+      if (restored.length === 0 && commentIds.length > 0) {
+        throw new Error('댓글 복구에 실패했습니다.');
+      }
+
+      return { restored, restoredIds, failedIds };
+    },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['commentSearch'] });
       void queryClient.invalidateQueries({ queryKey: ['comments'] });

--- a/src/domains/Comments/hooks/useRestoreComment.ts
+++ b/src/domains/Comments/hooks/useRestoreComment.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { restoreComment } from '@/apis';
+
+export const useRestoreComment = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (commentIds: number[]) =>
+      Promise.all(commentIds.map((commentId) => restoreComment(commentId))),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['commentSearch'] });
+      void queryClient.invalidateQueries({ queryKey: ['comments'] });
+      void queryClient.invalidateQueries({ queryKey: ['postComments'] });
+    },
+    onError: (error) => {
+      console.error('댓글 복구 중 오류 발생:', error);
+    },
+  });
+};

--- a/src/domains/Posts/components/PostDetail/PostDetailActionModal.tsx
+++ b/src/domains/Posts/components/PostDetail/PostDetailActionModal.tsx
@@ -31,6 +31,7 @@ export default function PostDetailActionModal({
         : modalType === 'RESTORE'
           ? '복구'
           : '삭제';
+  const requiresReason = modalType !== 'RESTORE';
 
   return (
     <div
@@ -42,16 +43,20 @@ export default function PostDetailActionModal({
           게시글 {actionText} 처리
         </h3>
         <p className='mb-4 text-xs text-gray-500'>
-          상태를 변경하는 사유를 작성해 주세요. (필수 입력)
+          {requiresReason
+            ? '상태를 변경하는 사유를 작성해 주세요. (필수 입력)'
+            : '삭제된 게시글을 공개 상태로 복구합니다.'}
         </p>
 
         <div className='flex flex-col gap-4'>
-          <textarea
-            className='min-h-[100px] w-full rounded-lg border border-gray-300 p-3 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none'
-            placeholder='변경 사유를 입력하세요...'
-            value={reason}
-            onChange={(e) => onReasonChange(e.target.value)}
-          />
+          {requiresReason && (
+            <textarea
+              className='min-h-[100px] w-full rounded-lg border border-gray-300 p-3 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none'
+              placeholder='변경 사유를 입력하세요...'
+              value={reason}
+              onChange={(e) => onReasonChange(e.target.value)}
+            />
+          )}
 
           {modalType === 'DELETE' && (
             <label className='mt-1 flex cursor-pointer items-center gap-2 text-xs font-semibold text-gray-600 select-none'>
@@ -78,7 +83,7 @@ export default function PostDetailActionModal({
               variant={modalType === 'DELETE' ? 'destructive' : 'default'}
               size='sm'
               onClick={onConfirm}
-              disabled={!reason.trim()}
+              disabled={requiresReason && !reason.trim()}
               className={`text-xs ${modalType === 'DELETE' ? 'bg-red-600 hover:bg-red-700' : 'bg-blue-600 hover:bg-blue-700'}`}
             >
               확인

--- a/src/domains/Posts/components/PostDetail/PostDetailCommentItem.tsx
+++ b/src/domains/Posts/components/PostDetail/PostDetailCommentItem.tsx
@@ -18,7 +18,7 @@ import { formatDateTimeWithAmPm } from '@/shared/utils';
 import type { AdminCommentResult } from '@/domains/Comments/types';
 import { getPostStatusBadges } from '@/domains/Comments/utils/commentUtils';
 
-import { deleteComment, updateCommentVisibility } from '@/apis';
+import { deleteComment, restoreComment, updateCommentVisibility } from '@/apis';
 
 interface PostDetailCommentItemProps {
   comment: AdminCommentResult;
@@ -74,6 +74,20 @@ export default function PostDetailCommentItem({
       toast.error('댓글 삭제에 실패했습니다.');
     },
   });
+
+  // 댓글 복구 Mutation
+  const restoreMutation = useMutation({
+    mutationFn: () => restoreComment(comment.commentId),
+    onSuccess: () => {
+      toast.success('댓글이 복구되었습니다.');
+      queryClient.invalidateQueries({ queryKey: ['postComments'] });
+      queryClient.invalidateQueries({ queryKey: ['post', comment.postId] });
+    },
+    onError: () => {
+      toast.error('댓글 복구에 실패했습니다.');
+    },
+  });
+
   const handleConfirmAction = (memo: string) => {
     if (!memo.trim()) return;
     if (modalType === 'HIDE') visibilityMutation.mutate(false);
@@ -170,18 +184,10 @@ export default function PostDetailCommentItem({
                 variant='outline'
                 size='sm'
                 className='h-7 rounded-md border-gray-300 bg-white px-2 text-xs font-medium text-gray-600 hover:bg-gray-100'
+                disabled={restoreMutation.isPending}
                 onClick={(e) => {
                   e.stopPropagation();
-
-                  // TODO: 추후 API 연동 완료 시 아래 플래그를 true로 변경하거나 블록 삭제
-                  const IS_READY = false;
-                  if (!IS_READY) {
-                    toast.info('댓글 복구 API 연동 예정입니다.');
-                    return;
-                  }
-
-                  setModalType('SHOW');
-                  setIsModalOpen(true);
+                  restoreMutation.mutate();
                 }}
               >
                 복구

--- a/src/domains/Posts/components/PostDetail/PostDetailManageCard.tsx
+++ b/src/domains/Posts/components/PostDetail/PostDetailManageCard.tsx
@@ -5,7 +5,7 @@ import { toast } from 'sonner';
 
 import { Button } from '@/shared/components/ui';
 
-import { deletePost } from '@/apis';
+import { deletePost, restorePost } from '@/apis';
 
 import type { AdminGetPostResponse } from '../../types';
 import PostDetailActionModal from './PostDetailActionModal';
@@ -49,6 +49,21 @@ export default function PostDetailManageCard({
       toast.error('게시글 삭제에 실패했습니다.');
     },
   });
+
+  const restoreMutation = useMutation({
+    mutationFn: () => restorePost(post.postId),
+    onSuccess: () => {
+      toast.success('게시글이 복구되었습니다.');
+      setIsModalOpen(false);
+      setReason('');
+      setDeleteCommentsAlso(false);
+      void queryClient.invalidateQueries({ queryKey: ['posts'] });
+      void queryClient.invalidateQueries({ queryKey: ['post', post.postId] });
+    },
+    onError: () => {
+      toast.error('게시글 복구에 실패했습니다.');
+    },
+  });
   // 게시글 관리 모달 상태
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalType, setModalType] = useState<
@@ -58,9 +73,11 @@ export default function PostDetailManageCard({
   const [deleteCommentsAlso, setDeleteCommentsAlso] = useState(false);
   // 모달 확인 클릭
   const handleConfirmAction = () => {
-    if (!reason.trim()) return;
     if (modalType === 'DELETE') {
+      if (!reason.trim()) return;
       deleteMutation.mutate(reason);
+    } else if (modalType === 'RESTORE') {
+      restoreMutation.mutate();
     } else {
       // TODO: DELETE 외(RESTORE, HIDE) API 연동 시 아래 로직 구현
       toast.info('개발 중입니다');

--- a/src/domains/Posts/hooks/usePostTableState.ts
+++ b/src/domains/Posts/hooks/usePostTableState.ts
@@ -6,6 +6,7 @@ import type { PostSearchParams } from '../types/post';
 import { useBulkDeletePost } from './useBulkDeletePost';
 import { useDeletePost } from './useDeletePost';
 import { usePostList } from './usePostList';
+import { useRestorePost } from './useRestorePost';
 import { useUpdatePostVisibility } from './useUpdatePostVisibility';
 
 interface UsePostTableStateProps {
@@ -75,6 +76,7 @@ export function usePostTableState({
   const { mutate: bulkDelete, isPending: isDeletePending } =
     useBulkDeletePost();
   const { mutate: singleDelete } = useDeletePost();
+  const { mutate: restorePost, isPending: isRestorePending } = useRestorePost();
   const { mutate: bulkVisibility, isPending: isVisibilityPending } =
     useUpdatePostVisibility();
 
@@ -126,24 +128,14 @@ export function usePostTableState({
   };
 
   const handleBulkRestore = () => {
-    // TODO: 추후 API 연동 완료 시 아래 플래그를 true로 변경하거나 블록 삭제
-    const IS_READY = false;
-    if (!IS_READY) {
-      toast.info('개발 중입니다');
-      return;
-    }
-
     if (selectedIds.length === 0) return;
-    bulkVisibility(
-      { postIds: selectedIds, isVisible: true },
-      {
-        onSuccess: () => {
-          toast.success('선택한 게시글과 댓글이 성공적으로 복구되었습니다.');
-          setSelectedIds([]);
-        },
-        onError: () => toast.error('게시글 복구 중 오류가 발생했습니다.'),
-      }
-    );
+    restorePost(selectedIds, {
+      onSuccess: (res) => {
+        toast.success(`${res.length}개의 게시글이 복구되었습니다.`);
+        setSelectedIds([]);
+      },
+      onError: () => toast.error('게시글 복구 중 오류가 발생했습니다.'),
+    });
   };
 
   const handleSingleDelete = (postId: number) => {
@@ -199,7 +191,7 @@ export function usePostTableState({
     handleBulkRestore,
     handleSingleDelete,
     isDeletePending,
-    isVisibilityPending,
+    isVisibilityPending: isVisibilityPending || isRestorePending,
     hasNext: hasNext ?? posts.length > 0,
     totalCount,
   };

--- a/src/domains/Posts/hooks/usePostTableState.ts
+++ b/src/domains/Posts/hooks/usePostTableState.ts
@@ -130,9 +130,17 @@ export function usePostTableState({
   const handleBulkRestore = () => {
     if (selectedIds.length === 0) return;
     restorePost(selectedIds, {
-      onSuccess: (res) => {
-        toast.success(`${res.length}개의 게시글이 복구되었습니다.`);
-        setSelectedIds([]);
+      onSuccess: ({ restored, restoredIds, failedIds }) => {
+        if (failedIds.length > 0) {
+          toast.warning(
+            `${restored.length}개의 게시글이 복구되었고, ${failedIds.length}개는 실패했습니다.`
+          );
+        } else {
+          toast.success(`${restored.length}개의 게시글이 복구되었습니다.`);
+        }
+
+        const restoredIdSet = new Set(restoredIds);
+        setSelectedIds((prev) => prev.filter((id) => !restoredIdSet.has(id)));
       },
       onError: () => toast.error('게시글 복구 중 오류가 발생했습니다.'),
     });

--- a/src/domains/Posts/hooks/useRestorePost.ts
+++ b/src/domains/Posts/hooks/useRestorePost.ts
@@ -2,12 +2,45 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { restorePost } from '@/apis';
 
+import type { AdminGetPostResponse } from '../types/post';
+
+interface RestorePostResult {
+  restored: AdminGetPostResponse[];
+  restoredIds: number[];
+  failedIds: number[];
+}
+
 export const useRestorePost = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (postIds: number[]) =>
-      Promise.all(postIds.map((postId) => restorePost(postId))),
+    mutationFn: async (postIds: number[]): Promise<RestorePostResult> => {
+      const results = await Promise.allSettled(
+        postIds.map((postId) => restorePost(postId))
+      );
+
+      const restored: AdminGetPostResponse[] = [];
+      const restoredIds: number[] = [];
+      const failedIds: number[] = [];
+
+      results.forEach((result, index) => {
+        const postId = postIds[index];
+
+        if (result.status === 'fulfilled') {
+          restored.push(result.value);
+          restoredIds.push(postId);
+          return;
+        }
+
+        failedIds.push(postId);
+      });
+
+      if (restored.length === 0 && postIds.length > 0) {
+        throw new Error('게시글 복구에 실패했습니다.');
+      }
+
+      return { restored, restoredIds, failedIds };
+    },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['posts'] });
       void queryClient.invalidateQueries({ queryKey: ['post'] });

--- a/src/domains/Posts/hooks/useRestorePost.ts
+++ b/src/domains/Posts/hooks/useRestorePost.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { restorePost } from '@/apis';
+
+export const useRestorePost = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (postIds: number[]) =>
+      Promise.all(postIds.map((postId) => restorePost(postId))),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['posts'] });
+      void queryClient.invalidateQueries({ queryKey: ['post'] });
+    },
+    onError: (error) => {
+      console.error('게시글 복구 중 오류 발생:', error);
+    },
+  });
+};


### PR DESCRIPTION
## 🔎 What is this PR?

Close #350

- [Figma]()
- [Notion]()

## 🎯 변경 사항

###### 주요 변경점을 설명해주세요.

- 게시글/댓글 복구 API와 복구 mutation 훅을 추가했습니다.
- 게시글/댓글 목록의 일괄 복구 액션을 실제 복구 API로 연결했습니다.
- 게시글 상세 복구 모달과 상세 댓글 복구 버튼을 복구 API로 연결했습니다.

## 📸 스크린샷 (선택 사항)

<!--
| Before | After |
| :----: | :---: |
|  |  |
-->

## 🧐 리뷰어가 어떤 부분에 집중해야 할까요? (선택 사항)

- 백엔드가 단건 복구 API만 제공해 일괄 복구는 선택된 ID별로 병렬 호출하도록 구현했습니다.
- 복구 API는 사유 body가 없어 게시글 복구 모달에서는 사유 입력 없이 확인할 수 있게 처리했습니다.